### PR TITLE
provide requestMetadata to datastore generation

### DIFF
--- a/lib/service/moduleGenerator.js
+++ b/lib/service/moduleGenerator.js
@@ -115,7 +115,7 @@ function generateModules(task) {
 
   return {
     backendContext: backendContext(appMetadata),
-    dataStore: dataStore(appMetadata, requestContext),
+    dataStore: dataStore(appMetadata, requestMetadata),
     email: email(proxyURL, taskMetadata, proxyTaskEmitter),
     kinveyEntity: entity(appMetadata._id, useBSONObjectId),
     kinveyDate,


### PR DESCRIPTION
@mjsalinger Per our conversation we should be passing the local metadata and not the actual module