### PR TITLE
allow custom header injection in response

### DIFF
--- a/lib/service/kinveyCompletionHandler.js
+++ b/lib/service/kinveyCompletionHandler.js
@@ -168,6 +168,10 @@ function createCompletionHandler(task, updateRequestBody, callback) {
 
         task.response.continue = true;
         return responseCallback(null, task);
+      },
+      setResponseHeaders(headers){
+          result.headers = headers;
+          return this;
       }
     };
 


### PR DESCRIPTION
Hello I want to suggest addition of one function "setResponseHeaders" that will allow developer to set custom header in response.

example usage:
        complete( JSON.parse(responseBody) )
                .ok()
                .setResponseHeaders({'x-ipm-response-sign': "header value"})  // this is new suggested function 
                .done();