### PR TITLE
BACK-2255 Change dataStore userStore options

### DIFF
--- a/lib/service/moduleGenerator.js
+++ b/lib/service/moduleGenerator.js
@@ -97,7 +97,8 @@ function generateModules(task) {
   };
   const taskMetadata = {
     taskType: task.taskType,
-    serviceObjectName: task.serviceObjectName,
+    objectName: task.request.serviceObjectName || task.request.objectName,
+    hookType: task.hookType,
     target: task.target,
     taskId: task.taskId,
     containerId: task.containerId
@@ -116,7 +117,7 @@ function generateModules(task) {
 
   return {
     backendContext: backendContext(appMetadata),
-    dataStore: dataStore(appMetadata, requestMetadata),
+    dataStore: dataStore(appMetadata, requestMetadata, taskMetadata),
     email: email(proxyURL, taskMetadata, proxyTaskEmitter),
     kinveyEntity: entity(appMetadata._id, useBSONObjectId),
     kinveyDate,
@@ -124,7 +125,7 @@ function generateModules(task) {
     Query,
     requestContext: requestContext(requestMetadata),
     tempObjectStore: tempObjectStore(task.request.tempObjectStore),
-    userStore: userStore(appMetadata, requestMetadata)
+    userStore: userStore(appMetadata, requestMetadata, taskMetadata)
   };
 }
 

--- a/lib/service/modules/baseStore.js
+++ b/lib/service/modules/baseStore.js
@@ -1,0 +1,90 @@
+/**
+ * Created by mjsalinger on 2/15/17.
+ */
+
+const request = require('request');
+
+class BaseStore {
+  constructor(storeOptions, appMetadata, requestContext, taskMetadata) {
+    this._appMetadata = appMetadata;
+    this._requestContext = requestContext;
+    this._taskMetadata = taskMetadata;
+    this._useBl = storeOptions.useBl || false;
+    this._useUserContext = storeOptions.useUserContext || false;
+
+    if (storeOptions.skipBl != null) {
+      this._useBl = storeOptions.skipBl === false;
+    }
+
+    if (storeOptions.useMasterSecret != null) {
+      this._useUserContext = storeOptions.useMasterSecret === false;
+    }
+
+    this._useMasterSecret = !(this._useUserContext);
+    this._skipBl = !(this._useBl);
+  }
+
+  _makeRequest(requestOptions, callback) {
+    request(requestOptions, (err, res, body) => {
+      if (err) {
+        return callback(err);
+      } else if (res.statusCode > 299) {
+        const error = new Error(body.error);
+        error.description = body.description;
+        error.debug = body.debug;
+        return callback(err);
+      }
+      return callback(null, body);
+    });
+  }
+
+  _buildKinveyRequest(baseRoute, collection, options) {
+    options = options || {};
+
+    if (baseRoute == null) {
+      throw new Error('Missing Base Route');
+    }
+
+    let url = `${this._appMetadata.baasUrl}/${baseRoute}/${this._appMetadata._id}/`;
+
+    if (collection != null) {
+      url += `${collection}/`;
+    }
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Kinvey-API-Version': this._requestContext.apiVersion,
+    };
+
+    if (this._useBl == null || this._useBl !== true) {
+      headers['x-kinvey-skip-business-logic'] = true;
+    }
+
+    const requestOptions = {
+      url,
+      headers,
+      json: true
+    };
+
+    if (options.useAppSecret === true) {
+      requestOptions.auth = {
+        user: this._appMetadata._id,
+        pass: this._appMetadata.appsecret
+      };
+    } else if ((this._useUserContext === true && options.useUserContext !== false) || options.useUserContext === true) {
+      requestOptions.headers.authorization = this._requestContext.authorization;
+    } else {
+      requestOptions.auth = {
+        user: this._appMetadata._id,
+        pass: this._appMetadata.mastersecret
+      };
+    }
+    return requestOptions;
+  }
+
+  _generateQueryString(query) {
+    return query.toQueryString();
+  }
+}
+
+module.exports = BaseStore;

--- a/lib/service/modules/dataStore.js
+++ b/lib/service/modules/dataStore.js
@@ -12,81 +12,29 @@
  * the License.
  */
 
-const request = require('request');
+const BaseStore = require('./baseStore');
+const BASE_ROUTE = 'appdata';
 
 // Initialize the DataStore; initializes to current User Context, unless useMasterSecret = true
 function initDataStore(appMetadata, requestContext, taskMetadata) {
-  function DataStore(storeOptions = {}) {
-    this.appMetadata = appMetadata;
-    this.requestContext = requestContext;
-    let useBl = this.useBl = storeOptions.useBl || false;
-    let useUserContext = this.useUserContext = storeOptions.useUserContext || false;
-
-    if (storeOptions.skipBl != null) {
-      useBl = this.useBl = storeOptions.skipBl === false;
+  class DataStore extends BaseStore {
+    _buildAppdataRequest(collectionName, options) {
+      return this._buildKinveyRequest(BASE_ROUTE, collectionName, options);
     }
 
-    if (storeOptions.useMasterSecret != null) {
-      useUserContext = this.useUserContext = storeOptions.useMasterSecret === false;
+    _makeAppdataRequest(requestOptions, collectionName, callback) {
+      if (this._taskMetadata.objectName === collectionName && (this._useBl === true || this._useUserContext === true)) {
+        const error = new Error('DataStoreError');
+        error.description = 'Not Allowed';
+        error.debug = 'Recursive data operations to the same collection cannot use user context or use BL.';
+        return callback(error);
+      }
+      return this._makeRequest(requestOptions, callback);
     }
 
-    function collection(collectionName) {
-      function _buildKinveyRequest() {
-        const url = `${appMetadata.baasUrl}/appdata/${appMetadata._id}/${collectionName}/`;
-        const headers = {
-          'Content-Type': 'application/json',
-          'X-Kinvey-API-Version': requestContext.apiVersion,
-        };
-
-        if (useBl == null || useBl !== true) {
-          headers['x-kinvey-skip-business-logic'] = true;
-        }
-
-        const requestOptions = {
-          url,
-          headers,
-          json: true
-        };
-
-        if (useUserContext === true) {
-          requestOptions.headers.authorization = requestContext.authorization;
-        } else {
-          requestOptions.auth = {
-            user: appMetadata._id,
-            pass: appMetadata.mastersecret
-          };
-        }
-
-        return requestOptions;
-      }
-
-      function _makeRequest(requestOptions, callback) {
-        if (taskMetadata.objectName === collectionName && (useBl === true || useUserContext === true)) {
-          const error = new Error('DataStoreError');
-          error.description = 'Not Allowed';
-          error.debug = 'Recursive data operations to the same collection cannot use user context or use BL.';
-          return callback(error);
-        }
-
-        request(requestOptions, (err, res, body) => {
-          if (err) {
-            return callback(err);
-          } else if (res.statusCode > 299) {
-            const error = new Error(body.error);
-            error.description = body.description;
-            error.debug = body.debug;
-            return callback(err);
-          }
-          return callback(null, body);
-        });
-      }
-
-      function _generateQueryString(query) {
-        return query.toQueryString();
-      }
-
-      function save(entity, callback) {
-        const requestOptions = _buildKinveyRequest();
+    collection(collectionName) {
+      const save = (entity, callback) => {
+        const requestOptions = this._buildAppdataRequest(collectionName);
 
         if (entity._id) {
           requestOptions.method = 'PUT';
@@ -97,10 +45,10 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
 
         requestOptions.body = entity;
 
-        _makeRequest(requestOptions, callback);
-      }
+        this._makeAppdataRequest(requestOptions, collectionName, callback);
+      };
 
-      function findById(entityId, callback) {
+      const findById = (entityId, callback) => {
         if (!entityId || typeof entityId === 'function') {
           callback = entityId;
           const err = new Error('DataStoreError');
@@ -109,15 +57,15 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
           return callback(err);
         }
 
-        const requestOptions = _buildKinveyRequest();
+        const requestOptions = this._buildAppdataRequest(collectionName);
 
         requestOptions.method = 'GET';
         requestOptions.url += entityId;
-        return _makeRequest(requestOptions, callback);
-      }
+        return this._makeAppdataRequest(requestOptions, collectionName, callback);
+      };
 
-      function find(query, callback) {
-        const requestOptions = _buildKinveyRequest();
+      const find = (query, callback) => {
+        const requestOptions = this._buildAppdataRequest(collectionName);
 
         if (typeof query === 'function' && !callback) {
           callback = query;
@@ -127,13 +75,13 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
         requestOptions.method = 'GET';
 
         if (query) {
-          requestOptions.qs = _generateQueryString(query);
+          requestOptions.qs = this._generateQueryString(query);
         }
 
-        return _makeRequest(requestOptions, callback);
-      }
+        return this._makeAppdataRequest(requestOptions, collectionName, callback);
+      };
 
-      function removeById(entityId, callback) {
+      const removeById = (entityId, callback) => {
         if (!entityId || typeof entityId === 'function') {
           callback = entityId;
           const err = new Error('DataStoreError');
@@ -142,15 +90,15 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
           return callback(err);
         }
 
-        const requestOptions = _buildKinveyRequest();
+        const requestOptions = this._buildAppdataRequest(collectionName);
 
         requestOptions.method = 'DELETE';
         requestOptions.url += entityId;
-        return _makeRequest(requestOptions, callback);
-      }
+        return this._makeAppdataRequest(requestOptions, collectionName, callback);
+      };
 
-      function remove(query, callback) {
-        const requestOptions = _buildKinveyRequest();
+      const remove = (query, callback) => {
+        const requestOptions = this._buildAppdataRequest(collectionName);
 
         if (typeof query === 'function' && !callback) {
           callback = query;
@@ -160,14 +108,14 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
         requestOptions.method = 'DELETE';
 
         if (query) {
-          requestOptions.qs = _generateQueryString(query);
+          requestOptions.qs = this._generateQueryString(query);
         }
 
-        return _makeRequest(requestOptions, callback);
-      }
+        return this._makeAppdataRequest(requestOptions, collectionName, callback);
+      };
 
-      function count(query, callback) {
-        const requestOptions = _buildKinveyRequest();
+      const count = (query, callback) => {
+        const requestOptions = this._buildAppdataRequest(collectionName);
 
         if (typeof query === 'function' && !callback) {
           callback = query;
@@ -178,11 +126,11 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
         requestOptions.url += '_count/';
 
         if (query) {
-          requestOptions.qs = _generateQueryString(query);
+          requestOptions.qs = this._generateQueryString(query);
         }
 
-        return _makeRequest(requestOptions, callback);
-      }
+        return this._makeAppdataRequest(requestOptions, collectionName, callback);
+      };
 
       return {
         save,
@@ -192,28 +140,18 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
         remove,
         count,
         collectionName,
-        _skipBl: !useBl,                    // Deprecated
-        _useMasterSecret: !useUserContext,  // Deprecated
-        _useUserContext: useUserContext,
-        _useBl: useBl,
-        _appMetadata: appMetadata,
-        _requestContext: requestContext
+        _skipBl: !(this._useBl),                    // Deprecated
+        _useMasterSecret: !(this._useUserContext),  // Deprecated
+        _useUserContext: this._useUserContext,
+        _useBl: this._useBl,
+        _appMetadata: this._appMetadata,
+        _requestContext: this._requestContext
       };
     }
-
-    return {
-      collection,
-      _useMasterSecret: !useUserContext,    // Deprecated
-      _useUserContext: useUserContext,
-      _appMetadata: appMetadata,
-      _requestContext: requestContext,
-      _skipBl: !useBl,
-      _useBl: useBl                         // Deprecated
-    };
   }
 
   function generateDataStore(storeOptions = {}) {
-    return new DataStore(storeOptions);
+    return new DataStore(storeOptions, appMetadata, requestContext, taskMetadata);
   }
 
   return generateDataStore;

--- a/lib/service/modules/dataStore.js
+++ b/lib/service/modules/dataStore.js
@@ -15,12 +15,20 @@
 const request = require('request');
 
 // Initialize the DataStore; initializes to current User Context, unless useMasterSecret = true
-function initDataStore(appMetadata, requestContext) {
+function initDataStore(appMetadata, requestContext, taskMetadata) {
   function DataStore(storeOptions = {}) {
     this.appMetadata = appMetadata;
     this.requestContext = requestContext;
-    const skipBl = this.skipBl = storeOptions.skipBl || false;
-    const useMasterSecret = this.useMasterSecret = storeOptions.useMasterSecret || false;
+    let useBl = this.useBl = storeOptions.useBl || false;
+    let useUserContext = this.useUserContext = storeOptions.useUserContext || false;
+
+    if (storeOptions.skipBl != null) {
+      useBl = this.useBl = storeOptions.skipBl === false;
+    }
+
+    if (storeOptions.useMasterSecret != null) {
+      useUserContext = this.useUserContext = storeOptions.useMasterSecret === false;
+    }
 
     function collection(collectionName) {
       function _buildKinveyRequest() {
@@ -30,7 +38,7 @@ function initDataStore(appMetadata, requestContext) {
           'X-Kinvey-API-Version': requestContext.apiVersion,
         };
 
-        if (skipBl) {
+        if (useBl == null || useBl !== true) {
           headers['x-kinvey-skip-business-logic'] = true;
         }
 
@@ -40,19 +48,26 @@ function initDataStore(appMetadata, requestContext) {
           json: true
         };
 
-        if (storeOptions.useMasterSecret) {
+        if (useUserContext === true) {
+          requestOptions.headers.authorization = requestContext.authorization;
+        } else {
           requestOptions.auth = {
             user: appMetadata._id,
             pass: appMetadata.mastersecret
           };
-        } else {
-          requestOptions.headers.authorization = requestContext.authorization;
         }
 
         return requestOptions;
       }
 
       function _makeRequest(requestOptions, callback) {
+        if (taskMetadata.objectName === collectionName && (useBl === true || useUserContext === true)) {
+          const error = new Error('DataStoreError');
+          error.description = 'Not Allowed';
+          error.debug = 'Recursive data operations to the same collection cannot use user context or use BL.';
+          return callback(error);
+        }
+
         request(requestOptions, (err, res, body) => {
           if (err) {
             return callback(err);
@@ -177,8 +192,10 @@ function initDataStore(appMetadata, requestContext) {
         remove,
         count,
         collectionName,
-        _skipBl: skipBl,
-        _useMasterSecret: useMasterSecret,
+        _skipBl: !useBl,                    // Deprecated
+        _useMasterSecret: !useUserContext,  // Deprecated
+        _useUserContext: useUserContext,
+        _useBl: useBl,
         _appMetadata: appMetadata,
         _requestContext: requestContext
       };
@@ -186,10 +203,12 @@ function initDataStore(appMetadata, requestContext) {
 
     return {
       collection,
-      _useMasterSecret: useMasterSecret,
+      _useMasterSecret: !useUserContext,    // Deprecated
+      _useUserContext: useUserContext,
       _appMetadata: appMetadata,
       _requestContext: requestContext,
-      _skipBl: skipBl
+      _skipBl: !useBl,
+      _useBl: useBl                         // Deprecated
     };
   }
 

--- a/lib/service/modules/userStore.js
+++ b/lib/service/modules/userStore.js
@@ -12,86 +12,27 @@
  * the License.
  */
 
-const request = require('request');
+const BaseStore = require('./baseStore');
+const BASE_ROUTE = 'user';
 
-// Initialize the DataStore; initializes to current User Context, unless useMasterSecret = true
+// Initialize the DataStore; initializes to mastersecret, unless useUserContext = true
 function initUserStore(appMetadata, requestContext, taskMetadata) {
-  function UserStore(storeOptions = {}) {
-    this.appMetadata = appMetadata;
-    this.requestContext = requestContext;
-
-    let useBl = this.useBl = storeOptions.useBl || false;
-    let useUserContext = this.useUserContext = storeOptions.useUserContext || false;
-
-    if (storeOptions.skipBl != null) {
-      useBl = this.useBl = storeOptions.skipBl === false;
+  class UserStore extends BaseStore {
+    _buildUserRequest(options) {
+      return this._buildKinveyRequest(BASE_ROUTE, null, options);
     }
 
-    if (storeOptions.useMasterSecret != null) {
-      useUserContext = this.useUserContext = storeOptions.useMasterSecret === false;
-    }
-
-    function _buildKinveyRequest(options = {}) {
-      const url = `${appMetadata.baasUrl}/user/${appMetadata._id}/`;
-
-      const headers = {
-        'Content-Type': 'application/json',
-        'X-Kinvey-API-Version': requestContext.apiVersion,
-      };
-
-      if (useBl == null || useBl !== true) {
-        headers['x-kinvey-skip-business-logic'] = true;
-      }
-
-      const requestOptions = {
-        url,
-        headers,
-        json: true
-      };
-
-      if (options.useAppSecret === true) {
-        requestOptions.auth = {
-          user: appMetadata._id,
-          pass: appMetadata.appsecret
-        };
-      } else if ((useUserContext === true || options.useUserContext === true) && options.useMasterSecret !== true) {
-        requestOptions.headers.authorization = requestContext.authorization;
-      } else {
-        requestOptions.auth = {
-          user: appMetadata._id,
-          pass: appMetadata.mastersecret
-        };
-      }
-
-      return requestOptions;
-    }
-
-    function _makeRequest(requestOptions, callback) {
-      if (taskMetadata.objectName === 'user' && (useBl === true || useUserContext === true)) {
+    _makeUserRequest(requestOptions, callback) {
+      if (this._taskMetadata.objectName === 'user' && (this._useBl === true || this._useUserContext === true)) {
         const error = new Error('UserStoreError');
         error.description = 'Not Allowed';
         error.debug = 'Recursive requests to the user store from the user store cannot use user credentials or use Bl';
         return callback(error);
       }
-
-      request(requestOptions, (err, res, body) => {
-        if (err) {
-          return callback(err);
-        } else if (res.statusCode > 299) {
-          const error = new Error(body.error);
-          error.description = body.description;
-          error.debug = body.debug;
-          return callback(err);
-        }
-        return callback(null, body);
-      });
+      return this._makeRequest(requestOptions, callback);
     }
 
-    function _generateQueryString(query) {
-      return query.toQueryString();
-    }
-
-    function create(user, callback) {
+    create(user, callback) {
       if (!user || typeof user === 'function') {
         callback = user;
         user = null;
@@ -102,15 +43,15 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
         return callback(error);
       }
 
-      const requestOptions = _buildKinveyRequest({ useAppSecret: true });
+      const requestOptions = this._buildUserRequest({ useAppSecret: true });
 
       requestOptions.method = 'POST';
       requestOptions.body = user;
 
-      return _makeRequest(requestOptions, callback);
+      return this._makeUserRequest(requestOptions, callback);
     }
 
-    function update(user, callback) {
+    update(user, callback) {
       if (!user || typeof user === 'function') {
         callback = user;
         user = null;
@@ -128,16 +69,16 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
         return callback(error);
       }
 
-      const requestOptions = _buildKinveyRequest();
+      const requestOptions = this._buildUserRequest();
 
       requestOptions.method = 'PUT';
       requestOptions.url += user._id;
       requestOptions.body = user;
 
-      return _makeRequest(requestOptions, callback);
+      return this._makeUserRequest(requestOptions, callback);
     }
 
-    function findById(userId, callback) {
+    findById(userId, callback) {
       if (!userId || typeof userId === 'function') {
         callback = userId;
         const err = new Error('UserStoreError');
@@ -146,19 +87,19 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
         return callback(err);
       }
 
-      const requestOptions = _buildKinveyRequest();
+      const requestOptions = this._buildUserRequest();
 
       requestOptions.method = 'GET';
       requestOptions.url += userId;
-      return _makeRequest(requestOptions, callback);
+      return this._makeUserRequest(requestOptions, callback);
     }
 
-    function getCurrentUser(callback) {
-      findById(requestContext.authenticatedUserId, callback);
+    getCurrentUser(callback) {
+      this.findById(requestContext.authenticatedUserId, callback);
     }
 
-    function find(query, callback) {
-      const requestOptions = _buildKinveyRequest();
+    find(query, callback) {
+      const requestOptions = this._buildUserRequest();
 
       if (typeof query === 'function' && !callback) {
         callback = query;
@@ -168,13 +109,13 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
       requestOptions.method = 'GET';
 
       if (query) {
-        requestOptions.qs = _generateQueryString(query);
+        requestOptions.qs = this._generateQueryString(query);
       }
 
-      return _makeRequest(requestOptions, callback);
+      return this._makeUserRequest(requestOptions, callback);
     }
 
-    function remove(userId, callback) {
+    remove(userId, callback) {
       if (!userId || typeof userId === 'function') {
         callback = userId;
         const err = new Error('UserStoreError');
@@ -183,7 +124,7 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
         return callback(err);
       }
 
-      const requestOptions = _buildKinveyRequest();
+      const requestOptions = this._buildUserRequest();
 
       requestOptions.method = 'DELETE';
       requestOptions.url += userId;
@@ -192,10 +133,10 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
         requestOptions.qs = { hard: true };
       }
 
-      return _makeRequest(requestOptions, callback);
+      return this._makeUserRequest(requestOptions, callback);
     }
 
-    function suspend(userId, callback) {
+    suspend(userId, callback) {
       if (!userId || typeof userId === 'function') {
         callback = userId;
         const err = new Error('UserStoreError');
@@ -204,7 +145,7 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
         return callback(err);
       }
 
-      const requestOptions = _buildKinveyRequest();
+      const requestOptions = this._buildUserRequest();
 
       requestOptions.method = 'DELETE';
       requestOptions.url += userId;
@@ -213,10 +154,10 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
         requestOptions.qs = { soft: true };
       }
 
-      return _makeRequest(requestOptions, callback);
+      return this._makeUserRequest(requestOptions, callback);
     }
 
-    function restore(userId, callback) {
+    restore(userId, callback) {
       if (!userId || typeof userId === 'function') {
         callback = userId;
         const err = new Error('UserStoreError');
@@ -225,16 +166,16 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
         return callback(err);
       }
 
-      const requestOptions = _buildKinveyRequest({ useMasterSecret: true });
+      const requestOptions = this._buildUserRequest({ useUserContext: false });
 
       requestOptions.method = 'POST';
       requestOptions.url += `${userId}/_restore`;
 
-      return _makeRequest(requestOptions, callback);
+      return this._makeUserRequest(requestOptions, callback);
     }
 
-    function count(query, callback) {
-      const requestOptions = _buildKinveyRequest();
+    count(query, callback) {
+      const requestOptions = this._buildUserRequest();
 
       if (typeof query === 'function' && !callback) {
         callback = query;
@@ -245,33 +186,16 @@ function initUserStore(appMetadata, requestContext, taskMetadata) {
       requestOptions.url += '_count/';
 
       if (query) {
-        requestOptions.qs = _generateQueryString(query);
+        requestOptions.qs = this._generateQueryString(query);
       }
 
-      return _makeRequest(requestOptions, callback);
+      return this._makeUserRequest(requestOptions, callback);
     }
 
-    return {
-      create,
-      update,
-      findById,
-      find,
-      getCurrentUser,
-      remove,
-      suspend,
-      restore,
-      count,
-      _skipBl: !useBl,                    // Deprecated
-      _useMasterSecret: !useUserContext,  // Deprecated
-      _useUserContext: useUserContext,
-      _useBl: useBl,
-      _appMetadata: this.appMetadata,
-      _requestContext: this.requestContext
-    };
   }
 
   function generateUserStore(storeOptions = {}) {
-    return new UserStore(storeOptions);
+    return new UserStore(storeOptions, appMetadata, requestContext, taskMetadata);
   }
 
   return generateUserStore;

--- a/lib/service/modules/userStore.js
+++ b/lib/service/modules/userStore.js
@@ -15,12 +15,21 @@
 const request = require('request');
 
 // Initialize the DataStore; initializes to current User Context, unless useMasterSecret = true
-function initUserStore(appMetadata, requestContext) {
+function initUserStore(appMetadata, requestContext, taskMetadata) {
   function UserStore(storeOptions = {}) {
     this.appMetadata = appMetadata;
     this.requestContext = requestContext;
-    const skipBl = this.skipBl = storeOptions.skipBl || false;
-    this.useMasterSecret = storeOptions.useMasterSecret || false;
+
+    let useBl = this.useBl = storeOptions.useBl || false;
+    let useUserContext = this.useUserContext = storeOptions.useUserContext || false;
+
+    if (storeOptions.skipBl != null) {
+      useBl = this.useBl = storeOptions.skipBl === false;
+    }
+
+    if (storeOptions.useMasterSecret != null) {
+      useUserContext = this.useUserContext = storeOptions.useMasterSecret === false;
+    }
 
     function _buildKinveyRequest(options = {}) {
       const url = `${appMetadata.baasUrl}/user/${appMetadata._id}/`;
@@ -30,7 +39,7 @@ function initUserStore(appMetadata, requestContext) {
         'X-Kinvey-API-Version': requestContext.apiVersion,
       };
 
-      if (skipBl) {
+      if (useBl == null || useBl !== true) {
         headers['x-kinvey-skip-business-logic'] = true;
       }
 
@@ -45,19 +54,26 @@ function initUserStore(appMetadata, requestContext) {
           user: appMetadata._id,
           pass: appMetadata.appsecret
         };
-      } else if (storeOptions.useMasterSecret || options.useMasterSecret) {
+      } else if ((useUserContext === true || options.useUserContext === true) && options.useMasterSecret !== true) {
+        requestOptions.headers.authorization = requestContext.authorization;
+      } else {
         requestOptions.auth = {
           user: appMetadata._id,
           pass: appMetadata.mastersecret
         };
-      } else {
-        requestOptions.headers.authorization = requestContext.authorization;
       }
 
       return requestOptions;
     }
 
     function _makeRequest(requestOptions, callback) {
+      if (taskMetadata.objectName === 'user' && (useBl === true || useUserContext === true)) {
+        const error = new Error('UserStoreError');
+        error.description = 'Not Allowed';
+        error.debug = 'Recursive requests to the user store from the user store cannot use user credentials or use Bl';
+        return callback(error);
+      }
+
       request(requestOptions, (err, res, body) => {
         if (err) {
           return callback(err);
@@ -138,14 +154,7 @@ function initUserStore(appMetadata, requestContext) {
     }
 
     function getCurrentUser(callback) {
-      const requestOptions = _buildKinveyRequest();
-
-      requestOptions.method = 'GET';
-      requestOptions.url += '_me';
-
-      requestOptions.headers.authorization = requestContext.authorization;
-
-      return _makeRequest(requestOptions, callback);
+      findById(requestContext.authenticatedUserId, callback);
     }
 
     function find(query, callback) {
@@ -218,7 +227,7 @@ function initUserStore(appMetadata, requestContext) {
 
       const requestOptions = _buildKinveyRequest({ useMasterSecret: true });
 
-      requestOptions.method = 'DELETE';
+      requestOptions.method = 'POST';
       requestOptions.url += `${userId}/_restore`;
 
       return _makeRequest(requestOptions, callback);
@@ -252,8 +261,10 @@ function initUserStore(appMetadata, requestContext) {
       suspend,
       restore,
       count,
-      _skipBl: this.skipBl,
-      _useMasterSecret: this.useMasterSecret,
+      _skipBl: !useBl,                    // Deprecated
+      _useMasterSecret: !useUserContext,  // Deprecated
+      _useUserContext: useUserContext,
+      _useBl: useBl,
       _appMetadata: this.appMetadata,
       _requestContext: this.requestContext
     };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-config-airbnb-base": "3.0.1",
     "eslint-plugin-import": "1.8.1",
     "mocha": "2.5.3",
-    "nock": "8.0.0",
+    "nock": "9.0.5",
     "proxyquire": "1.7.9",
     "should": "11.1.0",
     "sinon": "1.17.4",
@@ -59,6 +59,7 @@
     "test-push": "mocha test/lib/modules/push.test.js",
     "test-query": "mocha test/lib/modules/query.test.js",
     "test-requestcontext": "mocha test/lib/modules/requestContext.test.js",
-    "test-tempobjectstore": "mocha test/lib/modules/tempObjectStore.test.js"
+    "test-tempobjectstore": "mocha test/lib/modules/tempObjectStore.test.js",
+    "test-userStore": "mocha test/lib/modules/userStore.test.js"
   }
 }

--- a/test/lib/modules/dataStore.test.js
+++ b/test/lib/modules/dataStore.test.js
@@ -403,7 +403,7 @@ describe('dataStore', () => {
       });
     });
 
-    it('should find a single entity records using user context', (done) => {
+    it('should find a single entity record using user context', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
         .matchHeader('x-kinvey-api-version', '3')
@@ -935,7 +935,7 @@ describe('dataStore', () => {
       });
     });
 
-    it('should remove a single entity records using user context', (done) => {
+    it('should remove a single entity record using user context', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
         .matchHeader('x-kinvey-api-version', '3')

--- a/test/lib/modules/userStore.test.js
+++ b/test/lib/modules/userStore.test.js
@@ -365,7 +365,7 @@ describe('userStore', () => {
       });
     });
 
-    it('should find a single user records using user context', (done) => {
+    it('should find a single user record using user context', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
         .matchHeader('x-kinvey-api-version', '3')

--- a/test/lib/modules/userStore.test.js
+++ b/test/lib/modules/userStore.test.js
@@ -14,6 +14,7 @@
 
 const nock = require('nock');
 const should = require('should');
+const uuid = require('uuid');
 const userStore = require('../../../lib/service/modules/userStore');
 const Query = require('../../../lib/service/modules/query');
 const environmentId = 'kid1234';
@@ -50,21 +51,45 @@ function _generateRequestContext() {
   };
 }
 
+function _generateTaskMetadata() {
+  return {
+    taskType: 'data',
+    objectName: 'someObject',
+    hookType: undefined,
+    target: undefined,
+    taskId: uuid.v4(),
+    containerId: uuid.v4()
+  };
+}
+
+function _generateTaskMetadataForUser() {
+  return {
+    taskType: 'data',
+    objectName: 'user',
+    hookType: undefined,
+    target: undefined,
+    taskId: uuid.v4(),
+    containerId: uuid.v4()
+  };
+}
+
 describe('userStore', () => {
   beforeEach(() => {
     this.appMetadata = _generateAppMetadata();
     this.requestContext = _generateRequestContext();
+    this.taskMetadata = _generateTaskMetadata();
+    this.taskMetadataUser = _generateTaskMetadataForUser();
   });
 
   it('should initialize userstore', () => {
-    const store = userStore(this.appMetadata, this.requestContext);
+    const store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
     store.should.be.a.Function();
     store.name.should.eql('generateUserStore');
   });
 
   describe('userstore object', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
     });
 
     afterEach(() => {
@@ -100,12 +125,15 @@ describe('userStore', () => {
       myStore.restore.name.should.eql('restore');
       myStore.count.should.be.a.Function();
       myStore.count.name.should.eql('count');
-      myStore._useMasterSecret.should.be.false();
-      myStore._skipBl.should.be.false();
+      myStore._useMasterSecret.should.be.true();                              // DEPRECATED
+      myStore._skipBl.should.be.true();                                       // DEPRECATED
+      myStore._useUserContext.should.be.false();
+      myStore._useBl.should.be.false();
       myStore._appMetadata.should.containDeep(this.appMetadata);
       myStore._requestContext.should.containDeep(this.requestContext);
     });
 
+    // DEPRECATED
     it('should create a UserStore object that uses mastersecret', () => {
       const myStore = this.store({ useMasterSecret: true });
       myStore._useMasterSecret.should.be.true();
@@ -113,6 +141,14 @@ describe('userStore', () => {
       myStore._requestContext.should.containDeep(this.requestContext);
     });
 
+    it('should create a UserStore object that uses userContext', () => {
+      const myStore = this.store({ useUserContext: true });
+      myStore._useUserContext.should.be.true();
+      myStore._appMetadata.should.containDeep(this.appMetadata);
+      myStore._requestContext.should.containDeep(this.requestContext);
+    });
+
+    // DEPRECATED
     it('should create a UserStore object that skips BL', () => {
       const myStore = this.store({ skipBl: true });
       myStore._skipBl.should.be.true();
@@ -120,13 +156,20 @@ describe('userStore', () => {
       myStore._requestContext.should.containDeep(this.requestContext);
     });
 
-    it('should be able to create two UserStore objects with different settings', () => {
-      const myStore = this.store();
-      const myStore2 = this.store({ useMasterSecret: true });
-      myStore._useMasterSecret.should.be.false();
+    it('should create a UserStore object that uses BL', () => {
+      const myStore = this.store({ useBl: true });
+      myStore._useBl.should.be.true();
       myStore._appMetadata.should.containDeep(this.appMetadata);
       myStore._requestContext.should.containDeep(this.requestContext);
-      myStore2._useMasterSecret.should.be.true();
+    });
+
+    it('should be able to create two UserStore objects with different settings', () => {
+      const myStore = this.store();
+      const myStore2 = this.store({ useUserContext: true });
+      myStore._useUserContext.should.be.false();
+      myStore._appMetadata.should.containDeep(this.appMetadata);
+      myStore._requestContext.should.containDeep(this.requestContext);
+      myStore2._useUserContext.should.be.true();
       myStore2._appMetadata.should.containDeep(this.appMetadata);
       myStore2._requestContext.should.containDeep(this.requestContext);
     });
@@ -136,7 +179,7 @@ describe('userStore', () => {
       secondAppMetadata._id = 'abcd';
 
       const myStore = this.store();
-      const myStore2 = userStore(secondAppMetadata, this.requestContext)();
+      const myStore2 = userStore(secondAppMetadata, this.requestContext, this.taskMetadata)();
 
       myStore._appMetadata._id.should.eql(this.appMetadata._id);
       myStore2._appMetadata._id.should.eql(secondAppMetadata._id);
@@ -147,7 +190,7 @@ describe('userStore', () => {
       secondRequestContext.authenticatedUserId = 'foo';
 
       const myStore = this.store();
-      const myStore2 = userStore(this.appMetadata, secondRequestContext)();
+      const myStore2 = userStore(this.appMetadata, secondRequestContext, this.taskMetadata)();
 
       myStore._requestContext.authenticatedUserId.should.eql(this.requestContext.authenticatedUserId);
       myStore2._requestContext.authenticatedUserId.should.eql(secondRequestContext.authenticatedUserId);
@@ -156,7 +199,8 @@ describe('userStore', () => {
 
   describe('find', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
+      this.storeUserRequest = userStore(this.appMetadata, this.requestContext, this.taskMetadataUser);
     });
 
     afterEach(() => {
@@ -165,9 +209,14 @@ describe('userStore', () => {
 
     it('should find all records', (done) => {
       nock('https://baas.kinvey.com')
-        .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+       .matchHeader('content-type', 'application/json')
+       .matchHeader('x-kinvey-api-version', '3')
+       .matchHeader('x-kinvey-skip-business-logic', 'true')
         .get(`/user/${environmentId}/`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200, [{ _id: 123, username: 'abc' }, { _id: 456, username: 'xyz' }]);
 
       this.store().find((err, result) => {
@@ -177,10 +226,26 @@ describe('userStore', () => {
       });
     });
 
-    it('should find all records using mastersecret', (done) => {
+    it('should find all records using userContext', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .matchHeader('authorization', authorization)
+        .get(`/user/${environmentId}/`)
+        .reply(200, [{ _id: 123, username: 'abc' }, { _id: 456, username: 'xyz' }]);
+
+      this.store({ useUserContext: true }).find((err, result) => {
+        should.not.exist(err);
+        result.should.containDeep([{ _id: 123, username: 'abc' }, { _id: 456, username: 'xyz' }]);
+        return done();
+      });
+    });
+
+    it('should find all records and use bl', (done) => {
+      nock('https://baas.kinvey.com', { badheaders: ['x-kinvey-skip-business-logic'] })
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
         .get(`/user/${environmentId}/`)
         .basicAuth({
           user: environmentId,
@@ -188,22 +253,59 @@ describe('userStore', () => {
         })
         .reply(200, [{ _id: 123, username: 'abc' }, { _id: 456, username: 'xyz' }]);
 
-      this.store({ useMasterSecret: true }).find((err, result) => {
+      this.store({ useBl: true }).find((err, result) => {
         should.not.exist(err);
         result.should.containDeep([{ _id: 123, username: 'abc' }, { _id: 456, username: 'xyz' }]);
         return done();
       });
     });
 
-    it('should find all records and skip bl', (done) => {
+    it('should prevent recursive requests to the same object that use bl', (done) => {
+      this.storeUserRequest({ useBl: true }).find((err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context', (done) => {
+      this.storeUserRequest({ useUserContext: true }).find((err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context and bl', (done) => {
+      this.storeUserRequest({ useUserContext: true, useBl: true }).find((err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should allow recursive requests to the same object that use mastersecret and skip bl', (done) => {
       nock('https://baas.kinvey.com')
-        .matchHeader('x-kinvey-skip-business-logic', true)
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .get(`/user/${environmentId}/`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200, [{ _id: 123, username: 'abc' }, { _id: 456, username: 'xyz' }]);
 
-      this.store({ skipBl: true }).find((err, result) => {
+      this.storeUserRequest().find((err, result) => {
         should.not.exist(err);
         result.should.containDeep([{ _id: 123, username: 'abc' }, { _id: 456, username: 'xyz' }]);
         return done();
@@ -213,8 +315,13 @@ describe('userStore', () => {
     it('should find records with a query object', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .get(`/user/${environmentId}/`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .query({ query: '{"foo":"bar"}' })
         .reply(200, [{ _id: 123, username: 'abc' }, { _id: 456, username: 'xyz' }]);
 
@@ -231,18 +338,24 @@ describe('userStore', () => {
 
   describe('findById', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
+      this.storeUserRequest = userStore(this.appMetadata, this.requestContext, this.taskMetadataUser);
     });
 
     afterEach(() => {
       nock.cleanAll();
     });
 
-    it('should find a user', (done) => {
+    it('should find a single user', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .get(`/user/${environmentId}/1234`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200, { _id: 1234, username: 'abc' });
 
       this.store().findById(1234, (err, result) => {
@@ -252,10 +365,74 @@ describe('userStore', () => {
       });
     });
 
-    it('should find a single user records using mastersecret', (done) => {
+    it('should find a single user records using user context', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .matchHeader('authorization', authorization)
+        .get(`/user/${environmentId}/1234`)
+        .reply(200, { _id: 1234, username: 'abc' });
+
+      this.store({ useUserContext: true }).findById(1234, (err, result) => {
+        should.not.exist(err);
+        result.should.containDeep({ _id: 1234, username: 'abc' });
+        return done();
+      });
+    });
+
+    it('should find a single user and use bl', (done) => {
+      nock('https://baas.kinvey.com', { badheaders: ['x-kinvey-skip-business-logic'] })
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
+        .get(`/user/${environmentId}/1234`)
+        .reply(200, { _id: 1234, someData: 'abc' });
+
+      this.store({ useBl: true }).findById('1234', (err, result) => {
+        should.not.exist(err);
+        result.should.containDeep({ _id: 1234, someData: 'abc' });
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use bl', (done) => {
+      this.storeUserRequest({ useBl: true }).findById('1234', (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context', (done) => {
+      this.storeUserRequest({ useUserContext: true }).findById('1234', (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context and bl', (done) => {
+      this.storeUserRequest({ useUserContext: true, useBl: true }).findById('1234', (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should allow recursive requests to the same object that use mastersecret and skip bl', (done) => {
+      nock('https://baas.kinvey.com')
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .get(`/user/${environmentId}/1234`)
         .basicAuth({
           user: environmentId,
@@ -263,24 +440,9 @@ describe('userStore', () => {
         })
         .reply(200, { _id: 1234, username: 'abc' });
 
-      this.store({ useMasterSecret: true }).findById(1234, (err, result) => {
+      this.storeUserRequest().findById(1234, (err, result) => {
         should.not.exist(err);
         result.should.containDeep({ _id: 1234, username: 'abc' });
-        return done();
-      });
-    });
-
-    it('should find a single user and skip bl', (done) => {
-      nock('https://baas.kinvey.com')
-        .matchHeader('x-kinvey-skip-business-logic', true)
-        .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
-        .get(`/user/${environmentId}/1234`)
-        .reply(200, { _id: 1234, someData: 'abc' });
-
-      this.store({ skipBl: true }).findById('1234', (err, result) => {
-        should.not.exist(err);
-        result.should.containDeep({ _id: 1234, someData: 'abc' });
         return done();
       });
     });
@@ -298,7 +460,8 @@ describe('userStore', () => {
 
   describe('getCurrentUser', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
+      this.storeUserRequest = userStore(this.appMetadata, this.requestContext, this.taskMetadataUser);
     });
 
     afterEach(() => {
@@ -308,28 +471,84 @@ describe('userStore', () => {
     it('should get the current user entity', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
-        .get(`/user/${environmentId}/_me`)
-        .reply(200, { _id: 1234, username: 'abc' });
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .get(`/user/${environmentId}/${authenticatedUserId}`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
+        .reply(200, { _id: `${authenticatedUserId}`, username: 'abc' });
 
       this.store().getCurrentUser((err, result) => {
         should.not.exist(err);
-        result.should.containDeep({ _id: 1234, username: 'abc' });
+        result.should.containDeep({ _id: `${authenticatedUserId}`, username: 'abc' });
         return done();
       });
     });
 
-    it('should find a single user and skip bl', (done) => {
-      nock('https://baas.kinvey.com')
-        .matchHeader('x-kinvey-skip-business-logic', true)
+    it('should get the current user and use bl', (done) => {
+      nock('https://baas.kinvey.com', { badheaders: ['x-kinvey-skip-business-logic'] })
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
-        .get(`/user/${environmentId}/_me`)
+        .matchHeader('x-kinvey-api-version', '3')
+        .get(`/user/${environmentId}/${authenticatedUserId}`)
         .reply(200, { _id: 1234, someData: 'abc' });
 
-      this.store({ skipBl: true }).getCurrentUser((err, result) => {
+      this.store({ useBl: true }).getCurrentUser((err, result) => {
         should.not.exist(err);
         result.should.containDeep({ _id: 1234, someData: 'abc' });
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use bl', (done) => {
+      this.storeUserRequest({ useBl: true }).getCurrentUser((err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context', (done) => {
+      this.storeUserRequest({ useUserContext: true }).getCurrentUser((err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context and bl', (done) => {
+      this.storeUserRequest({ useUserContext: true, useBl: true }).getCurrentUser((err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should allow recursive requests to the same object that use mastersecret and skip bl', (done) => {
+      nock('https://baas.kinvey.com')
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .get(`/user/${environmentId}/${authenticatedUserId}`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
+        .reply(200, { _id: `${authenticatedUserId}`, username: 'abc' });
+
+      this.storeUserRequest().getCurrentUser((err, result) => {
+        should.not.exist(err);
+        result.should.containDeep({ _id: `${authenticatedUserId}`, username: 'abc' });
         return done();
       });
     });
@@ -347,7 +566,8 @@ describe('userStore', () => {
 
   describe('create', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
+      this.storeUserRequest = userStore(this.appMetadata, this.requestContext, this.taskMetadataUser);
     });
 
     afterEach(() => {
@@ -357,7 +577,8 @@ describe('userStore', () => {
     it('should create a new entity', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .post(`/user/${environmentId}/`, {
           username: 'abc'
         })
@@ -374,10 +595,11 @@ describe('userStore', () => {
       });
     });
 
-    it('should create a new entity using appsecret, even if mastersecret is specified for the store', (done) => {
+    it('should create a new entity using appsecret', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .post(`/user/${environmentId}/`, {
           username: 'abc'
         })
@@ -387,18 +609,17 @@ describe('userStore', () => {
         })
         .reply(200, { _id: 1234, username: 'abc' });
 
-      this.store({ useMasterSecret: true }).create({ username: 'abc' }, (err, result) => {
+      this.store().create({ username: 'abc' }, (err, result) => {
         should.not.exist(err);
         result.should.containDeep({ _id: 1234, username: 'abc' });
         return done();
       });
     });
 
-    it('should create a new entity and skip bl', (done) => {
-      nock('https://baas.kinvey.com')
-        .matchHeader('x-kinvey-skip-business-logic', true)
+    it('should create a new entity and use bl', (done) => {
+      nock('https://baas.kinvey.com', { badheaders: ['x-kinvey-skip-business-logic'] })
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
         .post(`/user/${environmentId}/`, {
           username: 'abc'
         })
@@ -408,7 +629,61 @@ describe('userStore', () => {
         })
         .reply(200, { _id: 1234, username: 'abc' });
 
-      this.store({ skipBl: true }).create({ username: 'abc' }, (err, result) => {
+      this.store({ useBl: true }).create({ username: 'abc' }, (err, result) => {
+        should.not.exist(err);
+        result.should.containDeep({ _id: 1234, username: 'abc' });
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use bl', (done) => {
+      this.storeUserRequest({ useBl: true }).create({ username: 'abc' }, (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context', (done) => {
+      this.storeUserRequest({ useUserContext: true }).create({ username: 'abc' }, (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context and bl', (done) => {
+      this.storeUserRequest({ useUserContext: true, useBl: true }).create({ username: 'abc' }, (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should allow recursive requests to the same object that use mastersecret and skip bl', (done) => {
+      nock('https://baas.kinvey.com')
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .post(`/user/${environmentId}/`, {
+          username: 'abc'
+        })
+        .basicAuth({
+          user: environmentId,
+          pass: appsecret
+        })
+        .reply(200, { _id: 1234, username: 'abc' });
+
+      this.storeUserRequest().create({ username: 'abc' }, (err, result) => {
         should.not.exist(err);
         result.should.containDeep({ _id: 1234, username: 'abc' });
         return done();
@@ -428,7 +703,8 @@ describe('userStore', () => {
 
   describe('update', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
+      this.storeUserRequest = userStore(this.appMetadata, this.requestContext, this.taskMetadataUser);
     });
 
     afterEach(() => {
@@ -438,24 +714,8 @@ describe('userStore', () => {
     it('should update an existing user', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
-        .put(`/user/${environmentId}/1234`, {
-          _id: 1234,
-          username: 'abc'
-        })
-        .reply(200, { _id: 1234, username: 'abc' });
-
-      this.store().update({ _id: 1234, username: 'abc' }, (err, result) => {
-        should.not.exist(err);
-        result.should.containDeep({ _id: 1234, username: 'abc' });
-        return done();
-      });
-    });
-
-    it('should update an existing user using mastersecret', (done) => {
-      nock('https://baas.kinvey.com')
-        .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .put(`/user/${environmentId}/1234`, {
           _id: 1234,
           username: 'abc'
@@ -466,25 +726,102 @@ describe('userStore', () => {
         })
         .reply(200, { _id: 1234, username: 'abc' });
 
-      this.store({ useMasterSecret: true }).update({ _id: 1234, username: 'abc' }, (err, result) => {
+      this.store().update({ _id: 1234, username: 'abc' }, (err, result) => {
         should.not.exist(err);
         result.should.containDeep({ _id: 1234, username: 'abc' });
         return done();
       });
     });
 
-    it('should update an existing user and skip bl', (done) => {
+    it('should update an existing user using user context', (done) => {
       nock('https://baas.kinvey.com')
-        .matchHeader('x-kinvey-skip-business-logic', true)
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .matchHeader('authorization', authorization)
         .put(`/user/${environmentId}/1234`, {
           _id: 1234,
           username: 'abc'
         })
         .reply(200, { _id: 1234, username: 'abc' });
 
-      this.store({ skipBl: true }).update({ _id: 1234, username: 'abc' }, (err, result) => {
+      this.store({ useUserContext: true }).update({ _id: 1234, username: 'abc' }, (err, result) => {
+        should.not.exist(err);
+        result.should.containDeep({ _id: 1234, username: 'abc' });
+        return done();
+      });
+    });
+
+    it('should update an existing user and use bl', (done) => {
+      nock('https://baas.kinvey.com', { badheaders: ['x-kinvey-skip-business-logic'] })
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('content-type', 'application/json')
+        .put(`/user/${environmentId}/1234`, {
+          _id: 1234,
+          username: 'abc'
+        })
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
+        .reply(200, { _id: 1234, username: 'abc' });
+
+      this.store({ useBl: true }).update({ _id: 1234, username: 'abc' }, (err, result) => {
+        should.not.exist(err);
+        result.should.containDeep({ _id: 1234, username: 'abc' });
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use bl', (done) => {
+      this.storeUserRequest({ useBl: true }).update({ _id: 1234, username: 'abc' }, (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context', (done) => {
+      this.storeUserRequest({ useUserContext: true }).update({ _id: 1234, username: 'abc' }, (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context and bl', (done) => {
+      this.storeUserRequest({ useUserContext: true, useBl: true }).update({ _id: 1234, username: 'abc' }, (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should allow recursive requests to the same object that use mastersecret and skip bl', (done) => {
+      nock('https://baas.kinvey.com')
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .put(`/user/${environmentId}/1234`, {
+          _id: 1234,
+          username: 'abc'
+        })
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
+        .reply(200, { _id: 1234, username: 'abc' });
+
+      this.storeUserRequest().update({ _id: 1234, username: 'abc' }, (err, result) => {
         should.not.exist(err);
         result.should.containDeep({ _id: 1234, username: 'abc' });
         return done();
@@ -514,7 +851,8 @@ describe('userStore', () => {
 
   describe('remove', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
+      this.storeUserRequest = userStore(this.appMetadata, this.requestContext, this.taskMetadataUser);
     });
 
     afterEach(() => {
@@ -524,8 +862,13 @@ describe('userStore', () => {
     it('should remove a single user', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .delete(`/user/${environmentId}/1234?hard=true`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200);
 
       this.store().remove(1234, (err, result) => {
@@ -538,8 +881,13 @@ describe('userStore', () => {
     it('should not include hard=true if apiVersion is 1', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 1)
+        .matchHeader('x-kinvey-api-version', '1')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .delete(`/user/${environmentId}/1234`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200);
 
       const myStore = this.store();
@@ -552,10 +900,26 @@ describe('userStore', () => {
       });
     });
 
-    it('should remove a single user record using mastersecret', (done) => {
+    it('should remove a single user record using user context', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .matchHeader('authorization', authorization)
+        .delete(`/user/${environmentId}/1234?hard=true`)
+        .reply(200);
+
+      this.store({ useUserContext: true }).remove(1234, (err, result) => {
+        should.not.exist(err);
+        should.not.exist(result);
+        return done();
+      });
+    });
+
+    it('should remove a single entity and use bl', (done) => {
+      nock('https://baas.kinvey.com', { badheaders: ['x-kinvey-skip-business-logic'] })
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
         .delete(`/user/${environmentId}/1234?hard=true`)
         .basicAuth({
           user: environmentId,
@@ -563,22 +927,59 @@ describe('userStore', () => {
         })
         .reply(200);
 
-      this.store({ useMasterSecret: true }).remove(1234, (err, result) => {
+      this.store({ useBl: true }).remove('1234', (err, result) => {
         should.not.exist(err);
         should.not.exist(result);
         return done();
       });
     });
 
-    it('should remove a single entity and skip bl', (done) => {
+    it('should prevent recursive requests to the same object that use bl', (done) => {
+      this.storeUserRequest({ useBl: true }).remove('1234', (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context', (done) => {
+      this.storeUserRequest({ useUserContext: true }).remove('1234', (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context and bl', (done) => {
+      this.storeUserRequest({ useUserContext: true, useBl: true }).remove('1234', (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should allow recursive requests to the same object that use mastersecret and skip bl', (done) => {
       nock('https://baas.kinvey.com')
-        .matchHeader('x-kinvey-skip-business-logic', true)
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .delete(`/user/${environmentId}/1234?hard=true`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200);
 
-      this.store({ skipBl: true }).remove('1234', (err, result) => {
+      this.storeUserRequest().remove('1234', (err, result) => {
         should.not.exist(err);
         should.not.exist(result);
         return done();
@@ -598,7 +999,8 @@ describe('userStore', () => {
 
   describe('count', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
+      this.storeUserRequest = userStore(this.appMetadata, this.requestContext, this.taskMetadataUser);
     });
 
     afterEach(() => {
@@ -608,8 +1010,13 @@ describe('userStore', () => {
     it('should get a count of all users', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .get(`/user/${environmentId}/_count/`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200, { count: 30 });
 
       this.store().count((err, result) => {
@@ -619,10 +1026,26 @@ describe('userStore', () => {
       });
     });
 
-    it('should get a count of all users using mastersecret', (done) => {
+    it('should get a count of all users using user context', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .matchHeader('authorization', authorization)
+        .get(`/user/${environmentId}/_count/`)
+        .reply(200, { count: 30 });
+
+      this.store({ useUserContext: true }).count((err, result) => {
+        should.not.exist(err);
+        result.should.containDeep({ count: 30 });
+        return done();
+      });
+    });
+
+    it('should get a count of all users and use bl', (done) => {
+      nock('https://baas.kinvey.com', { badheaders: ['x-kinvey-skip-business-logic'] })
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
         .get(`/user/${environmentId}/_count/`)
         .basicAuth({
           user: environmentId,
@@ -630,22 +1053,59 @@ describe('userStore', () => {
         })
         .reply(200, { count: 30 });
 
-      this.store({ useMasterSecret: true }).count((err, result) => {
+      this.store({ useBl: true }).count((err, result) => {
         should.not.exist(err);
         result.should.containDeep({ count: 30 });
         return done();
       });
     });
 
-    it('should get a count of all users and skip bl', (done) => {
+    it('should prevent recursive requests to the same object that use bl', (done) => {
+      this.storeUserRequest({ useBl: true }).count((err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context', (done) => {
+      this.storeUserRequest({ useUserContext: true }).count((err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context and bl', (done) => {
+      this.storeUserRequest({ useUserContext: true, useBl: true }).count((err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should allow recursive requests to the same object that use mastersecret and skip bl', (done) => {
       nock('https://baas.kinvey.com')
-        .matchHeader('x-kinvey-skip-business-logic', true)
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .get(`/user/${environmentId}/_count/`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200, { count: 30 });
 
-      this.store({ skipBl: true }).count((err, result) => {
+      this.storeUserRequest().count((err, result) => {
         should.not.exist(err);
         result.should.containDeep({ count: 30 });
         return done();
@@ -655,8 +1115,13 @@ describe('userStore', () => {
     it('should get a count of records with a query object', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .get(`/user/${environmentId}/_count/`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .query({ query: '{"foo":"bar"}' })
         .reply(200, { count: 12 });
 
@@ -673,7 +1138,8 @@ describe('userStore', () => {
 
   describe('suspend', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
+      this.storeUserRequest = userStore(this.appMetadata, this.requestContext, this.taskMetadataUser);
     });
 
     afterEach(() => {
@@ -683,8 +1149,13 @@ describe('userStore', () => {
     it('should suspend a single user', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .delete(`/user/${environmentId}/1234`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200);
 
       this.store().suspend(1234, (err, result) => {
@@ -697,8 +1168,13 @@ describe('userStore', () => {
     it('should include soft=true if apiVersion is 1', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 1)
+        .matchHeader('x-kinvey-api-version', '1')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .delete(`/user/${environmentId}/1234?soft=true`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200);
 
       const myStore = this.store();
@@ -711,10 +1187,26 @@ describe('userStore', () => {
       });
     });
 
-    it('should suspend a single user record using mastersecret', (done) => {
+    it('should suspend a single user record using user context', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .matchHeader('authorization', authorization)
+        .delete(`/user/${environmentId}/1234`)
+        .reply(200);
+
+      this.store({ useUserContext: true }).suspend(1234, (err, result) => {
+        should.not.exist(err);
+        should.not.exist(result);
+        return done();
+      });
+    });
+
+    it('should remove a single entity and use bl', (done) => {
+      nock('https://baas.kinvey.com', { badheaders: ['x-kinvey-skip-business-logic'] })
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
         .delete(`/user/${environmentId}/1234`)
         .basicAuth({
           user: environmentId,
@@ -722,22 +1214,59 @@ describe('userStore', () => {
         })
         .reply(200);
 
-      this.store({ useMasterSecret: true }).suspend(1234, (err, result) => {
+      this.store({ useBl: true }).suspend('1234', (err, result) => {
         should.not.exist(err);
         should.not.exist(result);
         return done();
       });
     });
 
-    it('should remove a single entity and skip bl', (done) => {
+    it('should prevent recursive requests to the same object that use bl', (done) => {
+      this.storeUserRequest({ useBl: true }).suspend('1234', (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context', (done) => {
+      this.storeUserRequest({ useUserContext: true }).suspend('1234', (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context and bl', (done) => {
+      this.storeUserRequest({ useUserContext: true, useBl: true }).suspend('1234', (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should allow recursive requests to the same object that use mastersecret and skip bl', (done) => {
       nock('https://baas.kinvey.com')
-        .matchHeader('x-kinvey-skip-business-logic', true)
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
         .delete(`/user/${environmentId}/1234`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200);
 
-      this.store({ skipBl: true }).suspend('1234', (err, result) => {
+      this.storeUserRequest().suspend('1234', (err, result) => {
         should.not.exist(err);
         should.not.exist(result);
         return done();
@@ -757,7 +1286,8 @@ describe('userStore', () => {
 
   describe('restore', () => {
     beforeEach(() => {
-      this.store = userStore(this.appMetadata, this.requestContext);
+      this.store = userStore(this.appMetadata, this.requestContext, this.taskMetadata);
+      this.storeUserRequest = userStore(this.appMetadata, this.requestContext, this.taskMetadataUser);
     });
 
     afterEach(() => {
@@ -767,8 +1297,13 @@ describe('userStore', () => {
     it('should restore a single user', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
-        .delete(`/user/${environmentId}/1234/_restore`)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .post(`/user/${environmentId}/1234/_restore`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200);
 
       this.store().restore(1234, (err, result) => {
@@ -778,33 +1313,89 @@ describe('userStore', () => {
       });
     });
 
-    it('should restore a single user record using mastersecret', (done) => {
+    it('should restore a single user record and override user context with mastersecret', (done) => {
       nock('https://baas.kinvey.com')
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
-        .delete(`/user/${environmentId}/1234/_restore`)
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .post(`/user/${environmentId}/1234/_restore`)
         .basicAuth({
           user: environmentId,
           pass: mastersecret
         })
         .reply(200);
 
-      this.store({ useMasterSecret: true }).restore(1234, (err, result) => {
+      this.store({ useUserContext: true }).restore(1234, (err, result) => {
         should.not.exist(err);
         should.not.exist(result);
         return done();
       });
     });
 
-    it('should restore a single entity and skip bl', (done) => {
-      nock('https://baas.kinvey.com')
-        .matchHeader('x-kinvey-skip-business-logic', true)
+    it('should restore a single entity and use bl', (done) => {
+      nock('https://baas.kinvey.com', { badheaders: ['x-kinvey-skip-business-logic'] })
         .matchHeader('content-type', 'application/json')
-        .matchHeader('x-kinvey-api-version', 3)
-        .delete(`/user/${environmentId}/1234/_restore`)
+        .matchHeader('x-kinvey-api-version', '3')
+        .post(`/user/${environmentId}/1234/_restore`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
         .reply(200);
 
-      this.store({ skipBl: true }).restore('1234', (err, result) => {
+      this.store({ useBl: true }).restore('1234', (err, result) => {
+        should.not.exist(err);
+        should.not.exist(result);
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use bl', (done) => {
+      this.storeUserRequest({ useBl: true }).restore(1234, (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context', (done) => {
+      this.storeUserRequest({ useUserContext: true }).restore(1234, (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should prevent recursive requests to the same object that use user context and bl', (done) => {
+      this.storeUserRequest({ useUserContext: true, useBl: true }).restore(1234, (err, result) => {
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.eql('UserStoreError');
+        err.description.should.eql('Not Allowed');
+        err.debug.should.eql('Recursive requests to the user store from the user store cannot use user credentials or use Bl');
+        return done();
+      });
+    });
+
+    it('should allow recursive requests to the same object that use mastersecret and skip bl', (done) => {
+      nock('https://baas.kinvey.com')
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('x-kinvey-api-version', '3')
+        .matchHeader('x-kinvey-skip-business-logic', 'true')
+        .post(`/user/${environmentId}/1234/_restore`)
+        .basicAuth({
+          user: environmentId,
+          pass: mastersecret
+        })
+        .reply(200);
+
+      this.storeUserRequest().restore(1234, (err, result) => {
         should.not.exist(err);
         should.not.exist(result);
         return done();


### PR DESCRIPTION
* DEPRECATED:  useMasterSecret in dataStore and userStore
* DEPRECATED:  skipBl in dateStore and userStore
* Added `useUserContext` option to set userStore and dataStore to use the user context
* Added `useBl` option to set userStore and dataStore to execute BL for a request
* Default userStore and dataStore to use `mastersecret` credentials
* Default userStore and dataStore to skip BL processing
* Added logic to prevent infinite recursive requests to dataStore and userStore by enforcing skipping of BL and using of `mastersecret` credentials if the request is to the same object.