### PR TITLE
Set global maxSockets for http and https agents to 100

### DIFF
--- a/lib/flex.js
+++ b/lib/flex.js
@@ -12,6 +12,8 @@
  * the License.
  */
 
+const http = require('http');
+const https = require('https');
 const data = require('./service/data');
 const isNil = require('lodash.isnil');
 const flex = require('../package.json');
@@ -21,6 +23,9 @@ const moduleGenerator = require('./service/moduleGenerator');
 const logger = require('./service/logger');
 const receiver = require('kinvey-code-task-runner');
 const kinveyErrors = require('kinvey-datalink-errors');
+
+http.globalAgent.maxSockets = 100;
+https.globalAgent.maxSockets = 100;
 
 class Flex {
   constructor(options, callback) {


### PR DESCRIPTION
The current version of node allows for unlimited sockets per destination outgoing IP.  For Flex, we want to limit that to something more reasonable.  This change sets the http and https maxSockets to 100, which is the same value it is in BL.  