### PR TITLE
BACK-2319: Add auth headers to proxy requests, plus tests

### DIFF
--- a/lib/service/moduleGenerator.js
+++ b/lib/service/moduleGenerator.js
@@ -119,11 +119,11 @@ function generateModules(task) {
   return {
     backendContext: backendContext(appMetadata),
     dataStore: dataStore(appMetadata, requestMetadata, taskMetadata),
-    email: email(proxyURL, taskMetadata, proxyTaskEmitter),
+    email: email(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter),
     groupStore: groupStore(appMetadata, requestMetadata, taskMetadata),
     kinveyEntity: entity(appMetadata._id, useBSONObjectId),
     kinveyDate,
-    push: push(proxyURL, taskMetadata, proxyTaskEmitter),
+    push: push(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter),
     Query,
     requestContext: requestContext(requestMetadata),
     tempObjectStore: tempObjectStore(task.request.tempObjectStore),

--- a/lib/service/modules/email.js
+++ b/lib/service/modules/email.js
@@ -15,7 +15,7 @@
 const request = require('request');
 const req = request.defaults({});
 
-function emailModule(proxyURL, taskMetadata, proxyTaskEmitter) {
+function emailModule(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter) {
   function send(from, to, subject, textBody, replyTo, htmlBody, cc, bcc, callback) {
     // Abort if required email field params are not specified
     if (!to || !from || !subject || !textBody) {
@@ -54,7 +54,12 @@ function emailModule(proxyURL, taskMetadata, proxyTaskEmitter) {
 
     return req.post({
       url: `${proxyURL}/email/send`,
+      auth: {
+        user: appMetadata._id,
+        pass: appMetadata.mastersecret
+      },
       headers: {
+        'x-kinvey-app-id': appMetadata._id,
         'x-kinvey-container-id': taskMetadata.containerId,
         'x-kinvey-task-id': taskMetadata.taskId,
         'x-kinvey-wait-for-confirmation': proxyShouldWaitForConfirmation

--- a/lib/service/modules/push.js
+++ b/lib/service/modules/push.js
@@ -19,7 +19,12 @@ const req = request.defaults({});
 const MISSING_USER_PARAM_ERROR = "You must specify the 'users' parameter to send a push notification";
 const MISSING_MESSAGE_PARAM_ERROR = "You must specify the 'message' parameter to send a push notification";
 
-function kinveyPushModule(proxyURL, taskMetadata, proxyTaskEmitter) {
+function kinveyPushModule(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter) {
+  const authHeader = {
+    user: appMetadata._id,
+    pass: appMetadata.mastersecret
+  };
+
   function sendMessage(userEntities, message, callback) {
     let proxyShouldWaitForConfirmation = 'true';
 
@@ -33,7 +38,9 @@ function kinveyPushModule(proxyURL, taskMetadata, proxyTaskEmitter) {
 
     req.post({
       url: `${proxyURL}/push/sendMessage`,
+      auth: authHeader,
       headers: {
+        'x-kinvey-app-id': appMetadata._id,
         'x-kinvey-container-id': taskMetadata.containerId,
         'x-kinvey-task-id': taskMetadata.taskId,
         'x-kinvey-wait-for-confirmation': proxyShouldWaitForConfirmation
@@ -66,7 +73,9 @@ function kinveyPushModule(proxyURL, taskMetadata, proxyTaskEmitter) {
 
     req.post({
       url: `${proxyURL}/push/sendBroadcast`,
+      auth: authHeader,
       headers: {
+        'x-kinvey-app-id': appMetadata._id,
         'x-kinvey-container-id': taskMetadata.containerId,
         'x-kinvey-task-id': taskMetadata.taskId,
         'x-kinvey-wait-for-confirmation': proxyShouldWaitForConfirmation

--- a/test/lib/modules/email.test.js
+++ b/test/lib/modules/email.test.js
@@ -23,6 +23,10 @@ describe('modules / email', () => {
   let requestStub = null;
   const emitter = new EventEmitter();
   const fakeProxyURL = 'http://proxy.proxy';
+  const appMetadata = {
+    _id: 'kid_abcd1234',
+    mastersecret: '12345'
+  };
   const taskMetadata = {
     taskId: 'abcd1234',
     containerId: 'wxyz9876'
@@ -35,7 +39,7 @@ describe('modules / email', () => {
     requestDefaultsStub.returns(requestStub);
     require.cache[require.resolve('request')].exports.defaults = requestDefaultsStub;
     emailModule = require('../../../lib/service/modules/email');
-    emailInstance = emailModule(fakeProxyURL, taskMetadata, emitter);
+    emailInstance = emailModule(fakeProxyURL, appMetadata, taskMetadata, emitter);
     return done();
   });
   afterEach((done) => {
@@ -45,6 +49,13 @@ describe('modules / email', () => {
   it('does not require a callback', (done) => {
     requestStub.post.callsArg(1);
     (() => emailInstance.send('from', 'to', 'subject', 'textBody')).should.not.throw();
+    return done();
+  });
+  it('appends authorization header details to the request object', (done) => {
+    requestStub.post.callsArg(1);
+    (() => emailInstance.send('from', 'to', 'subject', 'textBody')).should.not.throw();
+    requestStub.post.args[0][0].auth.user.should.eql(appMetadata._id);
+    requestStub.post.args[0][0].auth.pass.should.eql(appMetadata.mastersecret);
     return done();
   });
   it('should include x-kinvey-wait-for-confirmation = false if no callback is specified', (done) => {

--- a/test/lib/modules/push.test.js
+++ b/test/lib/modules/push.test.js
@@ -33,6 +33,10 @@ describe('modules / push', () => {
     _id: 'id1'
   };
   const fakeProxyURL = 'http://proxy.proxy';
+  const appMetadata = {
+    _id: 'kid_abcd1234',
+    mastersecret: '12345'
+  };
   const taskMetadata = {
     taskId: 'abcd1234',
     containerId: 'wxyz9876'
@@ -45,7 +49,7 @@ describe('modules / push', () => {
     requestDefaultsStub.returns(requestStub);
     require.cache[require.resolve('request')].exports.defaults = requestDefaultsStub;
     pushModule = require('../../../lib/service/modules/push');
-    pushInstance = pushModule(fakeProxyURL, taskMetadata, emitter);
+    pushInstance = pushModule(fakeProxyURL, appMetadata, taskMetadata, emitter);
     return done();
   });
   afterEach((done) => {
@@ -64,6 +68,13 @@ describe('modules / push', () => {
     it('does not require a callback', (done) => {
       requestStub.post.callsArg(1);
       (() => pushInstance.send(recipients, 'hello')).should.not.throw();
+      return done();
+    });
+    it('appends authorization header details to the request object', (done) => {
+      requestStub.post.callsArg(1);
+      (() => pushInstance.send(recipients, 'hello')).should.not.throw();
+      requestStub.post.args[0][0].auth.user.should.eql(appMetadata._id);
+      requestStub.post.args[0][0].auth.pass.should.eql(appMetadata.mastersecret);
       return done();
     });
     it('should include x-kinvey-wait-for-confirmation = false if no callback is specified', (done) => {


### PR DESCRIPTION
Adds `Authorization` header to Kinvey Proxy requests (push, email). Plus tests.