### PR TITLE
BACK-2541: Send applicationId (instead of KID) and requestId to proxy email/push methods

### DIFF
--- a/lib/service/moduleGenerator.js
+++ b/lib/service/moduleGenerator.js
@@ -83,6 +83,7 @@ function generateModules(task) {
   const proxyURL = task.proxyURL;
   const appMetadata = {
     _id: task.appMetadata._id,
+    applicationId: task.appMetadata.applicationId,
     blFlags: task.appMetadata.blFlags,
     appsecret: task.appMetadata.appsecret,
     mastersecret: task.appMetadata.mastersecret,
@@ -94,7 +95,8 @@ function generateModules(task) {
     apiVersion: task.request.headers['x-kinvey-api-version'] || '1',
     authorization: task.request.headers.authorization,
     clientAppVersion,
-    customRequestProperties
+    customRequestProperties,
+    requestId: task.requestId
   };
   const taskMetadata = {
     taskType: task.taskType,
@@ -119,11 +121,11 @@ function generateModules(task) {
   return {
     backendContext: backendContext(appMetadata),
     dataStore: dataStore(appMetadata, requestMetadata, taskMetadata),
-    email: email(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter),
+    email: email(proxyURL, appMetadata, taskMetadata, requestMetadata, proxyTaskEmitter),
     groupStore: groupStore(appMetadata, requestMetadata, taskMetadata),
     kinveyEntity: entity(appMetadata._id, useBSONObjectId),
     kinveyDate,
-    push: push(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter),
+    push: push(proxyURL, appMetadata, taskMetadata, requestMetadata, proxyTaskEmitter),
     Query,
     requestContext: requestContext(requestMetadata),
     tempObjectStore: tempObjectStore(task.request.tempObjectStore),

--- a/lib/service/modules/email.js
+++ b/lib/service/modules/email.js
@@ -15,7 +15,7 @@
 const request = require('request');
 const req = request.defaults({});
 
-function emailModule(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter) {
+function emailModule(proxyURL, appMetadata, taskMetadata, requestMetadata, proxyTaskEmitter) {
   function send(from, to, subject, textBody, replyTo, htmlBody, cc, bcc, callback) {
     // Abort if required email field params are not specified
     if (!to || !from || !subject || !textBody) {
@@ -59,8 +59,8 @@ function emailModule(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter) {
         pass: appMetadata.mastersecret
       },
       headers: {
-        'x-kinvey-app-id': appMetadata._id,
-        'x-kinvey-container-id': taskMetadata.containerId,
+        'x-kinvey-application-id': appMetadata.applicationId,
+        'x-kinvey-request-id': requestMetadata.requestId,
         'x-kinvey-task-id': taskMetadata.taskId,
         'x-kinvey-wait-for-confirmation': proxyShouldWaitForConfirmation
       },

--- a/lib/service/modules/push.js
+++ b/lib/service/modules/push.js
@@ -19,7 +19,7 @@ const req = request.defaults({});
 const MISSING_USER_PARAM_ERROR = "You must specify the 'users' parameter to send a push notification";
 const MISSING_MESSAGE_PARAM_ERROR = "You must specify the 'message' parameter to send a push notification";
 
-function kinveyPushModule(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter) {
+function kinveyPushModule(proxyURL, appMetadata, taskMetadata, requestMetadata, proxyTaskEmitter) {
   const authHeader = {
     user: appMetadata._id,
     pass: appMetadata.mastersecret
@@ -40,8 +40,8 @@ function kinveyPushModule(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter)
       url: `${proxyURL}/push/sendMessage`,
       auth: authHeader,
       headers: {
-        'x-kinvey-app-id': appMetadata._id,
-        'x-kinvey-container-id': taskMetadata.containerId,
+        'x-kinvey-application-id': appMetadata.applicationId,
+        'x-kinvey-request-id': requestMetadata.requestId,
         'x-kinvey-task-id': taskMetadata.taskId,
         'x-kinvey-wait-for-confirmation': proxyShouldWaitForConfirmation
       },
@@ -75,8 +75,8 @@ function kinveyPushModule(proxyURL, appMetadata, taskMetadata, proxyTaskEmitter)
       url: `${proxyURL}/push/sendBroadcast`,
       auth: authHeader,
       headers: {
-        'x-kinvey-app-id': appMetadata._id,
-        'x-kinvey-container-id': taskMetadata.containerId,
+        'x-kinvey-application-id': appMetadata.applicationId,
+        'x-kinvey-request-id': requestMetadata.requestId,
         'x-kinvey-task-id': taskMetadata.taskId,
         'x-kinvey-wait-for-confirmation': proxyShouldWaitForConfirmation
       },

--- a/test/lib/moduleGenerator.test.js
+++ b/test/lib/moduleGenerator.test.js
@@ -18,6 +18,7 @@ const sampleTaskInfo = {
   appId: 12345,
   appMetadata: {
     _id: '12345',
+    applicationId: 'abc123',
     appsecret: 'appsecret',
     mastersecret: 'mastersecret',
     pushService: void 0,

--- a/test/lib/modules/email.test.js
+++ b/test/lib/modules/email.test.js
@@ -25,11 +25,14 @@ describe('modules / email', () => {
   const fakeProxyURL = 'http://proxy.proxy';
   const appMetadata = {
     _id: 'kid_abcd1234',
+    applicationId: 'abc123',
     mastersecret: '12345'
   };
   const taskMetadata = {
-    taskId: 'abcd1234',
-    containerId: 'wxyz9876'
+    taskId: 'abcd1234'
+  };
+  const requestMetadata = {
+    requestId: 'ea85600029b04a18a754d57629cff62d'
   };
   before((done) => {
     requestStub = {
@@ -39,7 +42,7 @@ describe('modules / email', () => {
     requestDefaultsStub.returns(requestStub);
     require.cache[require.resolve('request')].exports.defaults = requestDefaultsStub;
     emailModule = require('../../../lib/service/modules/email');
-    emailInstance = emailModule(fakeProxyURL, appMetadata, taskMetadata, emitter);
+    emailInstance = emailModule(fakeProxyURL, appMetadata, taskMetadata, requestMetadata, emitter);
     return done();
   });
   afterEach((done) => {
@@ -209,10 +212,12 @@ describe('modules / email', () => {
         requestBody.cc.should.eql('ccTest');
         requestBody.bcc.should.eql('bccTest');
         const outgoingRequestHeaders = requestStub.post.args[0][0].headers;
+        outgoingRequestHeaders.should.have.property('x-kinvey-application-id');
         outgoingRequestHeaders.should.have.property('x-kinvey-task-id');
-        outgoingRequestHeaders.should.have.property('x-kinvey-container-id');
+        outgoingRequestHeaders.should.have.property('x-kinvey-request-id');
+        outgoingRequestHeaders['x-kinvey-application-id'].should.equal(appMetadata.applicationId);
         outgoingRequestHeaders['x-kinvey-task-id'].should.equal(taskMetadata.taskId);
-        outgoingRequestHeaders['x-kinvey-container-id'].should.equal(taskMetadata.containerId);
+        outgoingRequestHeaders['x-kinvey-request-id'].should.equal(requestMetadata.requestId);
         return done();
       });
   });

--- a/test/lib/modules/push.test.js
+++ b/test/lib/modules/push.test.js
@@ -35,11 +35,14 @@ describe('modules / push', () => {
   const fakeProxyURL = 'http://proxy.proxy';
   const appMetadata = {
     _id: 'kid_abcd1234',
+    applicationId: 'abc123',
     mastersecret: '12345'
   };
   const taskMetadata = {
-    taskId: 'abcd1234',
-    containerId: 'wxyz9876'
+    taskId: 'abcd1234'
+  };
+  const requestMetadata = {
+    requestId: 'ea85600029b04a18a754d57629cff62d'
   };
   before((done) => {
     requestStub = {
@@ -49,7 +52,7 @@ describe('modules / push', () => {
     requestDefaultsStub.returns(requestStub);
     require.cache[require.resolve('request')].exports.defaults = requestDefaultsStub;
     pushModule = require('../../../lib/service/modules/push');
-    pushInstance = pushModule(fakeProxyURL, appMetadata, taskMetadata, emitter);
+    pushInstance = pushModule(fakeProxyURL, appMetadata, taskMetadata, requestMetadata, emitter);
     return done();
   });
   afterEach((done) => {
@@ -238,10 +241,12 @@ describe('modules / push', () => {
         const requestBody = requestStub.post.args[0][0].json;
         requestBody.messageContent.should.eql('hello');
         const outgoingRequestHeaders = requestStub.post.args[0][0].headers;
+        outgoingRequestHeaders.should.have.property('x-kinvey-application-id');
         outgoingRequestHeaders.should.have.property('x-kinvey-task-id');
-        outgoingRequestHeaders.should.have.property('x-kinvey-container-id');
+        outgoingRequestHeaders.should.have.property('x-kinvey-request-id');
+        outgoingRequestHeaders['x-kinvey-application-id'].should.equal(appMetadata.applicationId);
         outgoingRequestHeaders['x-kinvey-task-id'].should.equal(taskMetadata.taskId);
-        outgoingRequestHeaders['x-kinvey-container-id'].should.equal(taskMetadata.containerId);
+        outgoingRequestHeaders['x-kinvey-request-id'].should.equal(requestMetadata.requestId);
         return done();
       });
     });
@@ -328,10 +333,12 @@ describe('modules / push', () => {
           androidPayload
         });
         const outgoingRequestHeaders = requestStub.post.args[0][0].headers;
+        outgoingRequestHeaders.should.have.property('x-kinvey-application-id');
         outgoingRequestHeaders.should.have.property('x-kinvey-task-id');
-        outgoingRequestHeaders.should.have.property('x-kinvey-container-id');
+        outgoingRequestHeaders.should.have.property('x-kinvey-request-id');
+        outgoingRequestHeaders['x-kinvey-application-id'].should.equal(appMetadata.applicationId);
         outgoingRequestHeaders['x-kinvey-task-id'].should.equal(taskMetadata.taskId);
-        outgoingRequestHeaders['x-kinvey-container-id'].should.equal(taskMetadata.containerId);
+        outgoingRequestHeaders['x-kinvey-request-id'].should.equal(requestMetadata.requestId);
         return done();
       });
     });
@@ -411,10 +418,12 @@ describe('modules / push', () => {
           androidPayload
         });
         const outgoingRequestHeaders = requestStub.post.args[0][0].headers;
+        outgoingRequestHeaders.should.have.property('x-kinvey-application-id');
         outgoingRequestHeaders.should.have.property('x-kinvey-task-id');
-        outgoingRequestHeaders.should.have.property('x-kinvey-container-id');
+        outgoingRequestHeaders.should.have.property('x-kinvey-request-id');
+        outgoingRequestHeaders['x-kinvey-application-id'].should.equal(appMetadata.applicationId);
         outgoingRequestHeaders['x-kinvey-task-id'].should.equal(taskMetadata.taskId);
-        outgoingRequestHeaders['x-kinvey-container-id'].should.equal(taskMetadata.containerId);
+        outgoingRequestHeaders['x-kinvey-request-id'].should.equal(requestMetadata.requestId);
         return done();
       });
     });


### PR DESCRIPTION
Prior to this branch, the `KID` was sent (as opposed to the needed `applicationId`). Also adds the Kinvey request ID to proxy request headers for email/push functions. Plus tests