### PR TITLE
FLEX-171 Error handling

### DIFF
--- a/lib/flex.js
+++ b/lib/flex.js
@@ -92,7 +92,9 @@ class Flex {
         return completionCallback(null, task);
       }
 
-      return this[task.taskType].process(task, this.moduleGenerator.generate(task), completionCallback);
+      return this[task.taskType].process(task, this.moduleGenerator.generate(task), (taskWithError, task) => {
+        completionCallback(null, taskWithError || task);
+      });
     });
 
     receiver.start(options, taskReceivedCallback, (err) => {

--- a/test/lib/flex.test.js
+++ b/test/lib/flex.test.js
@@ -195,6 +195,31 @@ describe('service creation', () => {
     });
   });
 
+  it('should not call callback with an error when task result is an error', (done) => {
+    sdk.service((err, sdk) => {
+      const task = {
+        appMetadata: {
+          _id: '12345',
+        },
+        taskType: 'functions',
+        taskName: null, // this causes a validation error during process
+        method: 'GET',
+        request: {
+          method: 'GET',
+          headers: {},
+          body: {}
+        },
+        response: {}
+      };
+
+      mockTaskReceiver.taskReceived()(task, (err, result) => {
+        should.not.exist(err);
+        should.exist(result);
+        done();
+      });
+    });
+  });
+
   it('should reject a task if shared secret auth is enabled and the authKey is not included', (done) => {
     sdk.service({ sharedSecret: uuid.v4() }, (err, flex) => {
       const task = {


### PR DESCRIPTION
Each processor (data, functions, auth, etc) passes a task object to its callback. But when an error occurs, it passes the task as the error parameter, rather than the result parameter. This caused the ambiguous log message described in the ticket.

This fix seems odd, but I felt it's preferable to changing the way processors work, since it's covered in tests and so on. It's an odd behaviour, but it seems it's by design. So I've just patched the passing of the task to the receiver.