### PR TITLE
FLEX-379: Calling complete multiple times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lib-cov
 
 .idea
 .jshint
+.vscode
 
 pids
 logs

--- a/lib/service/auth.js
+++ b/lib/service/auth.js
@@ -18,7 +18,7 @@ const notImplementedHandler = require('./notImplementedHandler');
 const authFunctions = new Map();
 
 function logAlreadyResponded(handlerName) {
-  logger.error(`Attempted to respond more than once to the same flex auth request in handler "${handlerName}"`);
+  logger.error(`Invoked done() or next() more than once to the same FlexAuth request in handler "${handlerName}"`);
 }
 
 function getHandlers() {

--- a/lib/service/auth.js
+++ b/lib/service/auth.js
@@ -12,9 +12,14 @@
  * the License.
  */
 
+const logger = require('./logger');
 const notImplementedHandler = require('./notImplementedHandler');
 
 const authFunctions = new Map();
+
+function logAlreadyResponded(handlerName) {
+  logger.error(`Attempted to respond more than once to the same flex auth handler "${handlerName}"`);
+}
 
 function getHandlers() {
   return [...authFunctions.keys()];
@@ -41,8 +46,9 @@ function process(task, modules, callback) {
   }
 
   function authCompletionHandler(task, callback) {
+    let responseCallback = callback;
+
     function completionHandler(token) {
-      const responseCallback = callback;
       const result = task.response;
 
       function normalizeError(error) {
@@ -128,7 +134,8 @@ function process(task, modules, callback) {
           // TODO:  Ensure that the result is a valid auth response
 
           result.continue = false;
-          return responseCallback(null, task);
+          responseCallback(null, task);
+          responseCallback = logAlreadyResponded.bind(null, task.taskName);
         },
         done() {
           if (!result.statusCode) {
@@ -138,7 +145,8 @@ function process(task, modules, callback) {
           // TODO:  Ensure that the result is a valid auth response
 
           result.continue = false;
-          return responseCallback(null, task);
+          responseCallback(null, task);
+          responseCallback = logAlreadyResponded.bind(null, task.taskName);
         }
       };
 

--- a/lib/service/auth.js
+++ b/lib/service/auth.js
@@ -18,7 +18,7 @@ const notImplementedHandler = require('./notImplementedHandler');
 const authFunctions = new Map();
 
 function logAlreadyResponded(handlerName) {
-  logger.error(`Attempted to respond more than once to the same flex auth handler "${handlerName}"`);
+  logger.error(`Attempted to respond more than once to the same flex auth request in handler "${handlerName}"`);
 }
 
 function getHandlers() {

--- a/lib/service/kinveyCompletionHandler.js
+++ b/lib/service/kinveyCompletionHandler.js
@@ -12,12 +12,28 @@
  * the License.
  */
 
+const logger = require('./logger');
+
+function isFunctionHandler(taskType) {
+  return taskType === 'businessLogic' || taskType === 'functions'
+}
+
+function logAlreadyResponded(task) {
+  let message = 'Attempted to respond more than once to the same flex ';
+  if (isFunctionHandler(task.taskType)) {
+    message += `function request to "${task.taskName}"`;
+  } else {
+    message += `data request: ${task.request.method} /${task.request.serviceObjectName}`;
+  }
+  logger.error(message);
+}
+
 function createCompletionHandler(task, requestBody, cb) {
   const callback = !cb && typeof requestBody === 'function' ? requestBody : cb;
   const updateRequestBody = typeof requestBody === 'function' ? {} : requestBody;
+  let responseCallback = callback;
 
   function completionHandler(body) {
-    let responseCallback = callback;
     const result = {};
 
     function normalizeError(error) {
@@ -149,8 +165,7 @@ function createCompletionHandler(task, requestBody, cb) {
 
         task.response.continue = false;
         responseCallback(null, task);
-        responseCallback = () => null;
-        return responseCallback;
+        responseCallback = logAlreadyResponded.bind(null, task);
       },
       next() {
         if (!result.statusCode) {
@@ -171,8 +186,7 @@ function createCompletionHandler(task, requestBody, cb) {
 
         task.response.continue = true;
         responseCallback(null, task);
-        responseCallback = () => null;
-        return responseCallback;
+        responseCallback = logAlreadyResponded.bind(null, task);
       }
     };
 

--- a/lib/service/kinveyCompletionHandler.js
+++ b/lib/service/kinveyCompletionHandler.js
@@ -19,11 +19,11 @@ function isFunctionHandler(taskType) {
 }
 
 function logAlreadyResponded(task) {
-  let message = 'Attempted to respond more than once to the same flex ';
+  let message = 'Invoked done() or next() more than once to the same Flex ';
   if (isFunctionHandler(task.taskType)) {
-    message += `function request to "${task.taskName}"`;
+    message += `Functions request to "${task.taskName}"`;
   } else {
-    message += `data request: ${task.request.method} /${task.request.serviceObjectName}`;
+    message += `Data handler ${task.request.method} for ${task.request.serviceObjectName}`;
   }
   logger.error(message);
 }

--- a/lib/service/kinveyCompletionHandler.js
+++ b/lib/service/kinveyCompletionHandler.js
@@ -15,7 +15,7 @@
 const logger = require('./logger');
 
 function isFunctionHandler(taskType) {
-  return taskType === 'businessLogic' || taskType === 'functions'
+  return taskType === 'businessLogic' || taskType === 'functions';
 }
 
 function logAlreadyResponded(task) {

--- a/test/unit/lib/functions.test.js
+++ b/test/unit/lib/functions.test.js
@@ -214,7 +214,7 @@ describe('FlexFunctions', () => {
   });
   describe('completion handlers', () => {
     afterEach((done) => {
-      loggerMock.error.reset();
+      loggerMock.error.resetHistory();
       functions.clearAll();
       return done();
     });
@@ -674,32 +674,34 @@ describe('FlexFunctions', () => {
         return done();
       });
     });
-    ['next', 'done'].forEach((method) => {
-      it(`should log a message when attempting to respond more than once, when calling ${method}()`, (done) => {
-        const taskName = quickRandom();
-        const task = sampleTask(taskName);
+    ['next', 'done'].forEach((method1) => {
+      ['next', 'done'].forEach((method2) => {
+        it(`should log a message when attempting to respond more than once, by calling ${method1}() and then ${method2}()`, (done) => {
+          const taskName = quickRandom();
+          const task = sampleTask(taskName);
 
-        functions.register(taskName, (context, complete) => {
-          complete({ baz: 'bar' }).ok()[method]();
-          setTimeout(() => {
-            complete({ baz: 'not bar' }).ok()[method]();
-          }, 0);
+          functions.register(taskName, (context, complete) => {
+            complete({ baz: 'bar' }).ok()[method1]();
+            setTimeout(() => {
+              complete({ baz: 'not bar' }).ok()[method2]();
+            }, 0);
+          });
+
+          const processCallbackSpy = sinon.spy((err, result) => {
+            should.not.exist(err);
+            result.response.statusCode.should.eql(200);
+            const expectedBody = method1 === 'next' ? result.request.body : result.response.body;
+            expectedBody.should.eql({ baz: 'bar' });
+            result.response.continue.should.eql(method1 === 'next');
+          });
+
+          loggerMock.error = sinon.spy((message) => {
+            message.should.eql(`Invoked done() or next() more than once to the same Flex Functions request to "${task.taskName}"`);
+            done();
+          });
+
+          functions.process(task, null, processCallbackSpy);
         });
-
-        const processCallbackSpy = sinon.spy((err, result) => {
-          should.not.exist(err);
-          result.response.statusCode.should.eql(200);
-          const expectedBody = method === 'next' ? result.request.body : result.response.body;
-          expectedBody.should.eql({ baz: 'bar' });
-          result.response.continue.should.eql(method === 'next');
-        });
-
-        loggerMock.error = sinon.spy((message) => {
-          message.should.eql(`Attempted to respond more than once to the same flex function request to "${task.taskName}"`);
-          done();
-        });
-
-        functions.process(task, null, processCallbackSpy);
       });
     });
   });

--- a/test/unit/lib/mocks/loggerMock.js
+++ b/test/unit/lib/mocks/loggerMock.js
@@ -1,0 +1,4 @@
+const sinon = require('sinon');
+
+const loggerMock = { error: sinon.spy() };
+module.exports = loggerMock;


### PR DESCRIPTION
FLEX-379 Includes this and one more improvement. I am unsure about the way to approach the other and I will open a separate PR for it.

In this PR, I fix the scoping bug which prevented the callback variable overwriting. This avoids the unhandled exception which occurred as a result of responding more than once. I added a log message for it too. Added tests for next and done methods.