### PR TITLE
FLEX-379: Handle destroyed socket at time of response

### DIFF
--- a/lib/flex.js
+++ b/lib/flex.js
@@ -84,6 +84,13 @@ class Flex {
     const taskReceivedCallback = ((task, completionCallback) => {
       task.sdkVersion = this.version;
 
+      const complete = (err, task) => {
+        const didRespond = completionCallback(err, task);
+        if (!didRespond && options.type === 'tcp') {
+          this.logger.error(`Unable to send response to taskId ${task.taskId}. The request likely timed out.`);
+        }
+      };
+
       if (this.sharedSecret != null
         && task.taskType !== 'serviceDiscovery'
         && task.taskType !== 'logger'
@@ -98,7 +105,7 @@ class Flex {
         result.statusCode = result.body.statusCode;
         delete result.body.statusCode;
         task.response.continue = false;
-        return completionCallback(null, task);
+        return complete(null, task);
       }
 
       if ((!this[task.taskType]
@@ -112,7 +119,7 @@ class Flex {
         result.statusCode = result.body.statusCode;
         delete result.body.statusCode;
         task.response.continue = false;
-        return completionCallback(null, task);
+        return complete(null, task);
       }
 
       if (task.taskType === 'serviceDiscovery') {
@@ -127,11 +134,11 @@ class Flex {
             handlers: this.auth.getHandlers()
           }
         };
-        return completionCallback(null, task);
+        return complete(null, task);
       }
 
       return this[task.taskType].process(task, this.moduleGenerator.generate(task), (taskWithError, task) => {
-        completionCallback(null, taskWithError || task);
+        complete(null, taskWithError || task);
       });
     });
 

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -28,6 +28,13 @@ let terminated = false;
 http.globalAgent.maxSockets = 100;
 https.globalAgent.maxSockets = 100;
 
+function getPublicConnectionErrorMsg(receiverMsg) {
+  if (receiverMsg === 'Connection ended by client.') {
+    return 'Flex Service request timed out.';
+  }
+  return 'Unexpected network issue.';
+}
+
 class Flex {
   constructor(opt, cb) {
     const callback = !cb && typeof opt === 'function' ? opt : cb;
@@ -84,10 +91,10 @@ class Flex {
     const taskReceivedCallback = ((task, completionCallback) => {
       task.sdkVersion = this.version;
 
-      const complete = (err, task) => {
-        const didRespond = completionCallback(err, task);
-        if (!didRespond && options.type === 'tcp') {
-          this.logger.error(`Unable to send response to taskId ${task.taskId}. The request likely timed out.`);
+      const complete = (task) => {
+        const errorMsg = completionCallback(null, task);
+        if (errorMsg && options.type === 'tcp') {
+          this.logger.error(`Unable to send response to taskId ${task.taskId}: ${getPublicConnectionErrorMsg(errorMsg)}`);
         }
       };
 
@@ -105,7 +112,7 @@ class Flex {
         result.statusCode = result.body.statusCode;
         delete result.body.statusCode;
         task.response.continue = false;
-        return complete(null, task);
+        return complete(task);
       }
 
       if ((!this[task.taskType]
@@ -119,7 +126,7 @@ class Flex {
         result.statusCode = result.body.statusCode;
         delete result.body.statusCode;
         task.response.continue = false;
-        return complete(null, task);
+        return complete(task);
       }
 
       if (task.taskType === 'serviceDiscovery') {
@@ -134,11 +141,11 @@ class Flex {
             handlers: this.auth.getHandlers()
           }
         };
-        return complete(null, task);
+        return complete(task);
       }
 
       return this[task.taskType].process(task, this.moduleGenerator.generate(task), (taskWithError, task) => {
-        complete(null, taskWithError || task);
+        complete(taskWithError || task);
       });
     });
 

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -94,7 +94,7 @@ class Flex {
       const complete = (task) => {
         const errorMsg = completionCallback(null, task);
         if (errorMsg && options.type === 'tcp') {
-          this.logger.error(`Unable to send response to taskId ${task.taskId}: ${getPublicConnectionErrorMsg(errorMsg)}`);
+          this.logger.error(`Unable to send response for taskId ${task.taskId}: ${getPublicConnectionErrorMsg(errorMsg)}`);
         }
       };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-from": {
@@ -160,7 +160,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "asynckit": {
@@ -724,7 +724,7 @@
     },
     "express": {
       "version": "4.16.3",
-      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
         "accepts": "1.3.5",
@@ -906,7 +906,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -1079,7 +1079,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "1.1.2",
@@ -1297,9 +1297,9 @@
       "dev": true
     },
     "kinvey-code-task-runner": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/kinvey-code-task-runner/-/kinvey-code-task-runner-2.3.1.tgz",
-      "integrity": "sha512-HxSfxZ7HzE6GpLri+MBbrO2bPH83BvoE4NfmSXy4J3Qu/tf+zIlJNpI2GQekjq+QulNF5e1AoaAUAccTMCA1yQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/kinvey-code-task-runner/-/kinvey-code-task-runner-2.4.0.tgz",
+      "integrity": "sha512-6ppfyoHYYnAhxhUTTj3p6/eqF6xDFtF6g2x1OOO45Kd1xp94duOJXJZbKVkj/rHibHMSrxcKUSDJ12IGEZQSYg==",
       "requires": {
         "async": "1.5.2",
         "body-parser": "1.18.3",
@@ -1365,7 +1365,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bson": "0.4.23",
-    "kinvey-code-task-runner": "2.3.1",
+    "kinvey-code-task-runner": "2.4.0",
     "kinvey-datalink-errors": "0.3.2",
     "moment": "2.22.2",
     "request": "2.88.0",

--- a/test/unit/lib/flex.test.js
+++ b/test/unit/lib/flex.test.js
@@ -459,7 +459,7 @@ describe('service creation', () => {
 
       this.loggerMock.error.calledOnce.should.eql(true);
       this.loggerMock.error.firstCall.args.length.should.eql(1);
-      this.loggerMock.error.firstCall.args[0].should.eql(`Unable to send response to taskId ${task.taskId}: Flex Service request timed out.`);
+      this.loggerMock.error.firstCall.args[0].should.eql(`Unable to send response for taskId ${task.taskId}: Flex Service request timed out.`);
       done();
     });
   });
@@ -505,7 +505,7 @@ describe('service creation', () => {
 
       this.loggerMock.error.calledOnce.should.eql(true);
       this.loggerMock.error.firstCall.args.length.should.eql(1);
-      this.loggerMock.error.firstCall.args[0].should.eql(`Unable to send response to taskId ${task.taskId}: Unexpected network issue.`);
+      this.loggerMock.error.firstCall.args[0].should.eql(`Unable to send response for taskId ${task.taskId}: Unexpected network issue.`);
       done();
     });
   });

--- a/test/unit/lib/flex.test.js
+++ b/test/unit/lib/flex.test.js
@@ -444,7 +444,9 @@ describe('service creation', () => {
           headers: {},
           body: {}
         },
-        response: {}
+        response: {
+          headers: {}
+        }
       };
 
       sdk.functions.register('foo', (context, complete) => {
@@ -488,7 +490,9 @@ describe('service creation', () => {
           headers: {},
           body: {}
         },
-        response: {}
+        response: {
+          headers: {}
+        }
       };
 
       sdk.functions.register('foo', (context, complete) => {

--- a/test/unit/lib/flex.test.js
+++ b/test/unit/lib/flex.test.js
@@ -23,11 +23,20 @@ const mockTaskReceiver = require('./mocks/mockTaskReceiver.js');
 
 describe('service creation', () => {
   let sdk = null;
-  before((done) => {
-    sdk = proxyquire('../../../lib/flex', { 'kinvey-code-task-runner': mockTaskReceiver });
-    return done();
+
+  before(() => {
+    this.loggerMock = { error: sinon.spy() };
+    sdk = proxyquire('../../../lib/flex', {
+      'kinvey-code-task-runner': mockTaskReceiver,
+      './service/logger': this.loggerMock
+    });
   });
-  it('can create a new service', done =>
+
+  beforeEach(() => {
+    this.loggerMock.error = sinon.spy();
+  });
+
+  it('can create a new service', (done) => {
     sdk.service((err, flex) => {
       should.not.exist(err);
       should.exist(flex.data);
@@ -37,8 +46,9 @@ describe('service creation', () => {
       should.exist(flex.version);
       should.exist(flex.auth);
       flex.version.should.eql(flexPackageJson.version);
-      return done();
-    }));
+      done();
+    });
+  });
 
   it('should set the type to http by default', (done) => {
     const spy = sinon.spy(mockTaskReceiver, 'start');
@@ -405,6 +415,94 @@ describe('service creation', () => {
         should.not.exist(result.response.body.debug);
         done();
       });
+    });
+  });
+
+  it('should log a timeout error, if receiver returns a client disconnect error', (done) => {
+    process.env.SDK_RECEIVER = 'tcp';
+    sdk.service((err, sdk) => {
+      const task = {
+        taskId: `some id ${Math.random()}`,
+        appMetadata: {
+          _id: '12345',
+          appsecret: 'appsecret',
+          mastersecret: 'mastersecret',
+          pushService: undefined,
+          restrictions: {
+            level: 'starter'
+          },
+          API_version: 3,
+          name: 'DevApp',
+          platform: null
+        },
+        taskType: 'functions',
+        taskName: 'foo',
+        hookType: 'customEndpoint',
+        method: 'GET',
+        request: {
+          method: 'GET',
+          headers: {},
+          body: {}
+        },
+        response: {}
+      };
+
+      sdk.functions.register('foo', (context, complete) => {
+        complete().ok().done();
+      });
+
+      mockTaskReceiver.taskReceived()(task, (err, result) => {
+        return 'Connection ended by client.';
+      });
+
+      this.loggerMock.error.calledOnce.should.eql(true);
+      this.loggerMock.error.firstCall.args.length.should.eql(1);
+      this.loggerMock.error.firstCall.args[0].should.eql(`Unable to send response to taskId ${task.taskId}: Flex Service request timed out.`);
+      done();
+    });
+  });
+
+  it('should log an unknown network error, if receiver returns an error which isn\'t a client disconnect', (done) => {
+    process.env.SDK_RECEIVER = 'tcp';
+    sdk.service((err, sdk) => {
+      const task = {
+        taskId: `some id ${Math.random()}`,
+        appMetadata: {
+          _id: '12345',
+          appsecret: 'appsecret',
+          mastersecret: 'mastersecret',
+          pushService: undefined,
+          restrictions: {
+            level: 'starter'
+          },
+          API_version: 3,
+          name: 'DevApp',
+          platform: null
+        },
+        taskType: 'functions',
+        taskName: 'foo',
+        hookType: 'customEndpoint',
+        method: 'GET',
+        request: {
+          method: 'GET',
+          headers: {},
+          body: {}
+        },
+        response: {}
+      };
+
+      sdk.functions.register('foo', (context, complete) => {
+        complete().ok().done();
+      });
+
+      mockTaskReceiver.taskReceived()(task, (err, result) => {
+        return `Any other message ${Math.random()}`;
+      });
+
+      this.loggerMock.error.calledOnce.should.eql(true);
+      this.loggerMock.error.firstCall.args.length.should.eql(1);
+      this.loggerMock.error.firstCall.args[0].should.eql(`Unable to send response to taskId ${task.taskId}: Unexpected network issue.`);
+      done();
     });
   });
 });


### PR DESCRIPTION
This PR is related to [PR #30](https://github.com/Kinvey/kinvey-code-task-runner/pull/30) from `kinvey-code-task-runner`. While it will not change the behaviour of the SDK if merged before it, the dependency *version of the task runner must be changed* at some point.

This code handles the returned error message, if any, indicating whether the tcp server was able to write the response to the open socket and the reason for it - client sent a FIN packet, or connection was interrupted. We log this to std out for users to debug.