### PR TITLE
BACK-3709-Change-Flex-sdk-to-use-computed-API-version

### DIFF
--- a/lib/service/moduleGenerator.js
+++ b/lib/service/moduleGenerator.js
@@ -86,7 +86,7 @@ function generateModules(task) {
   const requestMetadata = {
     authenticatedUsername: task.request.username,
     authenticatedUserId: task.request.userId,
-    apiVersion: task.request.headers['x-kinvey-api-version'] || '1',
+    apiVersion: task.response.headers['x-kinvey-api-version'] || '3',
     authorization: task.request.headers.authorization,
     clientAppVersion,
     customRequestProperties,

--- a/test/unit/lib/flex.test.js
+++ b/test/unit/lib/flex.test.js
@@ -96,7 +96,9 @@ describe('service creation', () => {
           body: {},
           serviceObjectName: 'foo'
         },
-        response: {}
+        response: {
+          headers: {}
+        }
       };
 
       sdk.data.serviceObject('foo').onGetAll(() => {
@@ -132,7 +134,9 @@ describe('service creation', () => {
           headers: {},
           body: {}
         },
-        response: {}
+        response: {
+          headers: {}
+        }
       };
 
       sdk.functions.register('foo', () => done());
@@ -169,7 +173,9 @@ describe('service creation', () => {
             options: {}
           }
         },
-        response: {}
+        response: {
+          headers: {}
+        }
       };
 
       sdk.auth.register('foo', () => done());
@@ -210,7 +216,9 @@ describe('service creation', () => {
           headers: {},
           body: {}
         },
-        response: {}
+        response: {
+          headers: {}
+        }
       };
 
       mockTaskReceiver.taskReceived()(task, (err, result) => {
@@ -244,7 +252,9 @@ describe('service creation', () => {
           body: {},
           serviceObjectName: 'foo'
         },
-        response: {}
+        response: {
+          headers: {}
+        }
       };
 
       flex.data.serviceObject('foo').onGetAll((context, complete) => {
@@ -291,7 +301,9 @@ describe('service creation', () => {
           body: {},
           serviceObjectName: 'foo'
         },
-        response: {}
+        response: {
+          headers: {}
+        }
       };
 
       flex.data.serviceObject('foo').onGetAll((context, complete) => {
@@ -364,7 +376,9 @@ describe('service creation', () => {
           body: {},
           serviceObjectName: 'foo'
         },
-        response: {}
+        response: {
+          headers: {}
+        }
       };
 
       flex.data.serviceObject('foo').onGetAll((context, complete) => {


### PR DESCRIPTION
KCS computes the API version based on several criteria, and places the computed API version as a response header.  

Currently, flex-sdk only sets the API version if it is included in the request headers, which is only one method of setting the API version. This change reads the computed API version and uses that throughout the flex-sdk when making requests to KCS.  