### PR TITLE
KDEV-294: Update entities with ids on batch save

### DIFF
--- a/lib/service/modules/dataStore.js
+++ b/lib/service/modules/dataStore.js
@@ -54,21 +54,112 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
       const totalEntities = [];
       const totalErrors = [];
 
-      return new Promise((resolve, reject) => {
-        async.eachOfSeries(entitiesInBatches, (batch, i, cb) => {
-          requestOptions.body = batch;
-          this._makeRequest(requestOptions, (err, resBody) => {
-            if (err) return cb(err);
+      return async.eachOfSeries(entitiesInBatches, (batch, i, cb) => {
+        requestOptions.body = batch;
+        this._makeRequest(requestOptions, (err, resBody) => {
+          if (err) return cb(err);
 
-            totalEntities.push(...resBody.entities);
-            // change batch-specific index to absolute index
-            resBody.errors.forEach((e) => {
-              e.index = (SAVE_BATCH_SIZE * i) + e.index;
-            });
-            totalErrors.push(...resBody.errors);
-            cb();
+          totalEntities.push(...resBody.entities);
+          // change batch-specific index to absolute index
+          resBody.errors.forEach((e) => {
+            e.index = (SAVE_BATCH_SIZE * i) + e.index;
           });
-        }, (err) => {
+          totalErrors.push(...resBody.errors);
+          return cb();
+        });
+      }, (err) => {
+        if (err) {
+          return callback(err);
+        }
+        // form the result
+        const resBody = {
+          entities: totalEntities,
+          errors: totalErrors
+        };
+
+        return callback(null, resBody);
+      });
+    }
+
+    _saveSingle(entity, collectionName, callback) {
+      const requestOptions = this._buildAppdataRequest(collectionName);
+      if (entity._id) {
+        requestOptions.method = 'PUT';
+        requestOptions.url += entity._id;
+      } else {
+        requestOptions.method = 'POST';
+      }
+
+      requestOptions.body = entity;
+      return this._makeAppdataRequest(requestOptions, collectionName, callback);
+    }
+
+    _saveMany(entities, collectionName, callback) {
+      const totalEntities = new Array(entities.length);
+      const totalErrors = [];
+      const entitiesToInsert = [];
+
+      const updateEntities = (updateDone) => {
+        // Find entities with existing _id and update them one by one
+        async.eachOfSeries(entities, (entity, index, cb) => {
+          // Skip if entity should be inserted
+          if (!entity._id) {
+            entitiesToInsert.push((entity));
+            return cb();
+          }
+
+          // Return the original entity if the update fails
+          totalEntities[index] = entity;
+          return this._saveSingle(entity, collectionName, (err, result) => {
+            if (err) {
+              err.index = index;
+              totalErrors.push(err);
+              return cb(null);
+            }
+
+            totalEntities[index] = result;
+            return cb(null);
+          });
+        }, updateDone);
+      };
+
+      const insertEntities = (insertDone) => {
+        const requestOptions = this._buildAppdataRequest(collectionName);
+        requestOptions.method = 'POST';
+        this._makeAppdataBatchRequest(requestOptions, entitiesToInsert, collectionName, (err, result) => {
+          if (err) {
+            return insertDone(err);
+          }
+
+          // Merge insert result in total result
+          let nextFreeIndex = 0;
+          result.entities.forEach((entity, index) => {
+            let indexOffset = 0;
+            // Find the next free index in totalEntities to set the inserted object. Updated objects are already there
+            while (totalEntities[nextFreeIndex]) {
+              indexOffset += 1;
+              nextFreeIndex += 1;
+            }
+
+            totalEntities[nextFreeIndex] = entity;
+            nextFreeIndex += 1;
+
+            // Fix the error indexes that are greater than the current index
+            result.errors.forEach((error) => {
+              if (error.index >= index) {
+                error.index += indexOffset;
+              }
+            });
+          });
+
+          totalErrors.push(...result.errors);
+          totalErrors.sort((a, b) => a.index - b.index);
+          return insertDone();
+        });
+      };
+
+      return new Promise((resolve, reject) => {
+        async.series([updateEntities, insertEntities], (err) => {
           if (err) {
             return callback ? callback(err) : reject(err);
           }
@@ -93,20 +184,11 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
           return cb ? setImmediate(() => cb(err)) : Promise.reject(err);
         }
 
-        const requestOptions = this._buildAppdataRequest(collectionName);
-        if (!Array.isArray(entity) && entity._id) {
-          requestOptions.method = 'PUT';
-          requestOptions.url += entity._id;
-        } else {
-          requestOptions.method = 'POST';
+        if (Array.isArray(entity)) {
+          return this._saveMany(entity, collectionName, callback);
         }
 
-        if (Array.isArray(entity) && entity.length > SAVE_BATCH_SIZE) {
-          return this._makeAppdataBatchRequest(requestOptions, entity, collectionName, callback);
-        }
-
-        requestOptions.body = entity;
-        return this._makeAppdataRequest(requestOptions, collectionName, callback);
+        return this._saveSingle(entity, collectionName, callback);
       };
 
       const findById = (entityId, callback) => {

--- a/lib/service/modules/dataStore.js
+++ b/lib/service/modules/dataStore.js
@@ -131,28 +131,29 @@ function initDataStore(appMetadata, requestContext, taskMetadata) {
             return insertDone(err);
           }
 
+          // Map the errors by index for easier access
+          const errorsMap = {};
+          result.errors.forEach(e => errorsMap[e.index] = e);
+
           // Merge insert result in total result
           let nextFreeIndex = 0;
           result.entities.forEach((entity, index) => {
-            let indexOffset = 0;
             // Find the next free index in totalEntities to set the inserted object. Updated objects are already there
             while (totalEntities[nextFreeIndex]) {
-              indexOffset += 1;
               nextFreeIndex += 1;
             }
 
             totalEntities[nextFreeIndex] = entity;
-            nextFreeIndex += 1;
+            // If the entity is null, there must be a matching error. Update its index.
+            if (entity == null && errorsMap[index]) {
+              const insertErr = errorsMap[index];
+              insertErr.index = nextFreeIndex;
+              totalErrors.push(insertErr);
+            }
 
-            // Fix the error indexes that are greater than the current index
-            result.errors.forEach((error) => {
-              if (error.index >= index) {
-                error.index += indexOffset;
-              }
-            });
+            nextFreeIndex += 1;
           });
 
-          totalErrors.push(...result.errors);
           totalErrors.sort((a, b) => a.index - b.index);
           return insertDone();
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kinvey-flex-sdk",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinvey-flex-sdk",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "SDK for creating Kinvey Flex Services",
   "engines": {
     "node": "= 6.x.x"

--- a/package.json
+++ b/package.json
@@ -42,23 +42,6 @@
     "test": "npm run test-unit && npm run test-integration",
     "test-unit": "mocha test/unit/*/*",
     "test-integration": "echo \"No integration tests available for the moment\"",
-    "test-core": "mocha test/lib/*",
-    "test-flex": "mocha test/lib/flex.test.js",
-    "test-data": "mocha test/lib/data.test.js",
-    "test-functions": "mocha test/lib/functions.test.js",
-    "test-moduleGenerator": "mocha test/lib/moduleGenerator.test.js",
-    "test-modules": "mocha test/lib/modules/*",
-    "test-backendcontext": "mocha test/lib/modules/backendContext.test.js",
-    "test-dataStore": "mocha test/lib/modules/dataStore.test.js",
-    "test-email": "mocha test/lib/modules/email.test.js",
-    "test-groupStore": "mocha test/lib/modules/groupStore.test.js",
-    "test-entity": "mocha test/lib/modules/entity.test.js",
-    "test-kinveydate": "mocha test/lib/modules/kinveyDate.test.js",
-    "test-push": "mocha test/lib/modules/push.test.js",
-    "test-query": "mocha test/lib/modules/query.test.js",
-    "test-requestcontext": "mocha test/lib/modules/requestContext.test.js",
-    "test-tempobjectstore": "mocha test/lib/modules/tempObjectStore.test.js",
-    "test-userStore": "mocha test/lib/modules/userStore.test.js",
     "test-npm-security": "npm audit --production --audit-level=high"
   }
 }


### PR DESCRIPTION
`DataStore.collection.save` can be invoked with an array of entities. So far the SDK treated all these entities as new and tried to insert them, leading to errors for entities that already exist in the database.
Now the SDK PUTs the entities with `_id`s and POSTs just the new ones, using the multi-insert API.